### PR TITLE
POST /devices 409 status code for device already exists error

### DIFF
--- a/api_inventory.go
+++ b/api_inventory.go
@@ -86,7 +86,7 @@ func (i *InventoryHandlers) AddDeviceHandler(w rest.ResponseWriter, r *rest.Requ
 	err = inv.AddDevice(dev)
 	if err != nil {
 		if cause := errors.Cause(err); cause != nil && cause == ErrDuplicatedDeviceId {
-			restErrWithLogMsg(w, l, err, http.StatusBadRequest, "device with specified ID already exists")
+			restErrWithLogMsg(w, l, err, http.StatusConflict, "device with specified ID already exists")
 			return
 		}
 		restErrWithLogInternal(w, l, err)

--- a/api_inventory_test.go
+++ b/api_inventory_test.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"github.com/ant0ine/go-json-rest/rest"
 	"github.com/ant0ine/go-json-rest/rest/test"
 	"github.com/mendersoftware/inventory/config"
@@ -23,6 +22,7 @@ import (
 	"github.com/mendersoftware/inventory/requestid"
 	"github.com/mendersoftware/inventory/requestlog"
 	"github.com/mendersoftware/inventory/utils"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	. "github.com/stretchr/testify/mock"
 	"net/http"
@@ -214,6 +214,19 @@ func TestApiInventoryAddDevice(t *testing.T) {
 			JSONResponseParams: utils.JSONResponseParams{
 				OutputStatus:     http.StatusInternalServerError,
 				OutputBodyObject: RestError("internal error"),
+			},
+		},
+		"device ID already exists error": {
+			inReq: test.MakeSimpleRequest("POST",
+				"http://1.2.3.4/api/0.1.0/devices",
+				map[string]interface{}{
+					"id": "id-0001",
+				},
+			),
+			inventoryErr: errors.Wrap(ErrDuplicatedDeviceId, "failed to add device"),
+			JSONResponseParams: utils.JSONResponseParams{
+				OutputStatus:     http.StatusConflict,
+				OutputBodyObject: RestError("device with specified ID already exists"),
 			},
 		},
 	}

--- a/docs/api_spec.yml
+++ b/docs/api_spec.yml
@@ -84,6 +84,10 @@ paths:
           description: Bad request.
           schema:
             $ref: '#/definitions/Error'
+        409:
+          description: Conflict
+          schema:
+            $ref: '#/definitions/Error'
         500:
           description: Internal error.
           schema:


### PR DESCRIPTION
we added 409 status code for POST /devices when device already exists, beacuse @bboozzoo  needs to know in deviceauth about that specific case (400 is not enough, can be other error)

Issues: MEN-579
Signed-off-by: mswiecznik marek.swiecznik@rndity.com
