### PR TITLE
docs/devices: use correct device attributes endpoint

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -13,7 +13,7 @@ schemes:
   - https
 
 paths:
-  /attributes:
+  /device/attributes:
     patch:
       summary: Upload a set of attributes for a device
       description: |


### PR DESCRIPTION
Gateway configuration maps /api/devices/0.1/inventory/device/attributes
to /api/0.1.0/attributes.

See: https://github.com/mendersoftware/mender-api-gateway-docker/blob/master/nginx.conf#L86

@maciejmrowiec @mchalski @kjaskiewiczz @marekswiecznik 