### PR TITLE
docs: change attribute 'value' field type to 'string'

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -82,7 +82,7 @@ definitions:
         type: string
         description: Attribute description.
       value:
-        type: object
+        type: string
         description: |
             The current value of the attribute.
 

--- a/docs/integrations_api.yml
+++ b/docs/integrations_api.yml
@@ -356,7 +356,7 @@ definitions:
         type: string
         description: Attribute description.
       value:
-        type: object
+        type: string
         description: |
             The current value of the attribute.
 


### PR DESCRIPTION
helpful for tests - swagger python client doesn't handle 'object' well

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@GregorioDiStefano @maciejmrowiec 