### PR TITLE
config.yaml: don't override the default 'prod middleware' setting

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,4 +18,4 @@ mongo: mongo-inventory:27017
     #       production environment
     #
     # Defaults to: prod
-middleware: dev
+# middleware: dev


### PR DESCRIPTION
the dev vs prod middleware is already set up correctly, and controlled
via the 'middleware' setting/'dev' flag (with prod as default). the only problem is the config file
which overrides this setting, and is pulled into the docker image - hence
the stack traces from RecoverMiddleware by default.

Issues: MEN-898

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>