### PR TITLE
api: http: do replace 404 with 204 on DELETE if device was not found.

### DIFF
--- a/api_inventory.go
+++ b/api_inventory.go
@@ -251,16 +251,12 @@ func (i *InventoryHandlers) DeleteDeviceHandler(w rest.ResponseWriter, r *rest.R
 
 	err = inv.DeleteDevice(DeviceID(deviceID))
 
-	switch err {
-	case nil:
-		w.WriteHeader(http.StatusNoContent)
-	case ErrDevNotFound:
-		restErrWithLog(w, r, l, ErrDevNotFound, http.StatusNotFound)
-	default:
+	if err != nil && err != ErrDevNotFound {
 		restErrWithLogInternal(w, r, l, err)
+		return
 	}
 
-	return
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (i *InventoryHandlers) AddDeviceHandler(w rest.ResponseWriter, r *rest.Request) {

--- a/api_inventory_test.go
+++ b/api_inventory_test.go
@@ -1096,8 +1096,7 @@ func TestApiDeleteDevice(t *testing.T) {
 			inReq:        test.MakeSimpleRequest("DELETE", "http://1.2.3.4/api/0.1.0/devices/1", nil),
 			inventoryErr: ErrDevNotFound,
 			JSONResponseParams: utils.JSONResponseParams{
-				OutputStatus:     http.StatusNotFound,
-				OutputBodyObject: RestError(ErrDevNotFound.Error()),
+				OutputStatus: http.StatusNoContent,
 			},
 		},
 		"some device": {

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -215,10 +215,6 @@ paths:
       responses:
           204:
             description: Device removed
-          404:
-            description: Device not found
-            schema:
-              $ref: "#/definitions/Error"
           500:
             description: Internal server error.
             schema:


### PR DESCRIPTION
Do not return 404 if DELETE on /devices/{id} did not find any resources to
delete. In the end, the effect of DELETE if there was no device and if one was
removed is exactly the same (device is no longer present), but non-success
status may confuse some integration tools.

@maciejmrowiec @mendersoftware/rndity 