### PR TITLE
Changelog: Additional MongoDB configuration options: mongo_ssl, mongo…

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,15 @@ const (
 
 	SettingDb        = "mongo"
 	SettingDbDefault = "mongo-inventory:27017"
+
+	SettingDbSSL        = "mongo_ssl"
+	SettingDbSSLDefault = false
+
+	SettingDbSSLSkipVerify        = "mongo_ssl_skipverify"
+	SettingDbSSLSkipVerifyDefault = false
+
+	SettingDbUsername = "mongo_username"
+	SettingDbPassword = "mongo_password"
 )
 
 var (
@@ -34,5 +43,7 @@ var (
 		{Key: SettingListen, Value: SettingListenDefault},
 		{Key: SettingMiddleware, Value: SettingMiddlewareDefault},
 		{Key: SettingDb, Value: SettingDbDefault},
+		{Key: SettingDbSSL, Value: SettingDbSSLDefault},
+		{Key: SettingDbSSLSkipVerify, Value: SettingDbSSLSkipVerifyDefault},
 	}
 )

--- a/config.yaml
+++ b/config.yaml
@@ -6,9 +6,29 @@ listen: :8080
     # MongoDB is required to run the service
     # Format: [mongodb://][user:pass@]host1[:port1][,host2[:port2],...][?options]
     # Format doc: https://docs.mongodb.com/manual/reference/connection-string/
-    #
     # Defaults to: "mongo-inventory"
 mongo: mongo-inventory:27017
+
+    # Enable SSL for mongo connections
+    # Defaults to: false
+# mongo_ssl: false
+
+    # SkipVerify controls whether a mongo client verifies the
+    # server's certificate chain and host name.
+    # If InsecureSkipVerify is true, accepts any certificate
+    # presented by the server and any host name in that certificate.
+    # Defaults to: false
+# mongo_ssl_skipverify: false
+
+    # Mongodb username
+    # Overwrites username set in connection string.
+    # Defaults to: none
+# mongo_username: user
+
+    # Mongodb password
+    # Overwrites password set in connection string.
+    # Defaults to: none
+# mongo_password: secret
 
     # HTTP Server middleware environment
     # Available values:
@@ -16,6 +36,7 @@ mongo: mongo-inventory:27017
     #       development environment
     #   prod
     #       production environment
-    #
-    # Defaults to: prod
+   # Defaults to: prod
 # middleware: dev
+
+

--- a/main.go
+++ b/main.go
@@ -64,7 +64,16 @@ func main() {
 
 	ctx := context.Background()
 
-	db, err := mongo.NewDataStoreMongo(config.Config.GetString(SettingDb))
+	db, err := mongo.NewDataStoreMongo(
+		mongo.DataStoreMongoConfig{
+			ConnectionString: config.Config.GetString(SettingDb),
+
+			SSL:           config.Config.GetBool(SettingDbSSL),
+			SSLSkipVerify: config.Config.GetBool(SettingDbSSLSkipVerify),
+
+			Username: config.Config.GetString(SettingDbUsername),
+			Password: config.Config.GetString(SettingDbPassword),
+		})
 	if err != nil {
 		l.Fatal("failed to connect to db")
 	}

--- a/server.go
+++ b/server.go
@@ -45,7 +45,15 @@ func RunServer(c config.Reader) error {
 
 	l := log.New(log.Ctx{})
 
-	db, err := mongo.NewDataStoreMongo(c.GetString(SettingDb))
+	db, err := mongo.NewDataStoreMongo(
+		mongo.DataStoreMongoConfig{
+			ConnectionString: c.GetString(SettingDb),
+			SSL:              c.GetBool(SettingDbSSL),
+			SSLSkipVerify:    c.GetBool(SettingDbSSLSkipVerify),
+
+			Username: c.GetString(SettingDbUsername),
+			Password: c.GetString(SettingDbPassword),
+		})
 	if err != nil {
 		return errors.Wrap(err, "database connection failed")
 	}

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -16,7 +16,9 @@ package mongo
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -51,6 +53,19 @@ var (
 	once sync.Once
 )
 
+type DataStoreMongoConfig struct {
+	// MGO connection string
+	ConnectionString string
+
+	// SSL support
+	SSL           bool
+	SSLSkipVerify bool
+
+	// Overwrites credentials provided in connection string if provided
+	Username string
+	Password string
+}
+
 type DataStoreMongo struct {
 	session *mgo.Session
 }
@@ -59,22 +74,58 @@ func NewDataStoreMongoWithSession(session *mgo.Session) *DataStoreMongo {
 	return &DataStoreMongo{session: session}
 }
 
-func NewDataStoreMongo(host string) (*DataStoreMongo, error) {
+func NewDataStoreMongo(config DataStoreMongoConfig) (*DataStoreMongo, error) {
 	//init master session
 	var err error
 	once.Do(func() {
-		masterSession, err = mgo.Dial(host)
-		if err == nil {
-			// force write ack with immediate journal file fsync
-			masterSession.SetSafe(&mgo.Safe{
-				W: 1,
-				J: true,
-			})
+
+		var dialInfo *mgo.DialInfo
+		dialInfo, err = mgo.ParseURL(config.ConnectionString)
+		if err != nil {
+			return
 		}
+
+		// Set 10s timeout - same as set by Dial
+		dialInfo.Timeout = 10 * time.Second
+
+		if config.Username != "" {
+			dialInfo.Username = config.Username
+		}
+		if config.Password != "" {
+			dialInfo.Password = config.Password
+		}
+
+		if config.SSL {
+			dialInfo.DialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
+
+				// Setup TLS
+				tlsConfig := &tls.Config{}
+				tlsConfig.InsecureSkipVerify = config.SSLSkipVerify
+
+				conn, err := tls.Dial("tcp", addr.String(), tlsConfig)
+				return conn, err
+			}
+		}
+
+		masterSession, err = mgo.DialWithInfo(dialInfo)
+		if err != nil {
+			return
+		}
+
+		// Validate connection
+		if err = masterSession.Ping(); err != nil {
+			return
+		}
+
+		// force write ack with immediate journal file fsync
+		masterSession.SetSafe(&mgo.Safe{
+			W: 1,
+			J: true,
+		})
 	})
 
 	if err != nil {
-		return nil, errors.New("failed to open mgo session")
+		return nil, errors.Wrap(err, "failed to open mgo session")
 	}
 
 	db := &DataStoreMongo{session: masterSession}

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -440,10 +440,10 @@ func TestNewDataStoreMongo(t *testing.T) {
 		t.Skip("skipping TestNewDataStoreMongo in short mode.")
 	}
 
-	ds, err := NewDataStoreMongo("illegal url")
+	ds, err := NewDataStoreMongo(DataStoreMongoConfig{ConnectionString: "illegal url"})
 
 	assert.Nil(t, ds)
-	assert.EqualError(t, err, "failed to open mgo session")
+	assert.EqualError(t, err, "failed to open mgo session: no reachable servers")
 }
 
 func TestMongoUpsertAttributes(t *testing.T) {


### PR DESCRIPTION
…_ssl_skipverify, mongo_username, mongo_password

Allow to connect to MongoDB over TLS (if configured).
Additional options for specifying user/pass for cleaner management of secrets.

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>