### PR TITLE
travis/acceptance: use a different name for acceptance tests binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ script:
         git clone https://github.com/mendersoftware/integration.git integration_new ;
         cp integration_new/extra/travis-testing/* tests/ ;
 
-        CGO_ENABLED=0 go test -c -o inventory -coverpkg $(go list ./... | grep -v vendor | grep -v mock | grep -v test | tr  '\n' ,);
+        CGO_ENABLED=0 go test -c -o inventory-test -coverpkg $(go list ./... | grep -v vendor | grep -v mock | grep -v test | tr  '\n' ,);
         
         sudo docker build -f Dockerfile.acceptance-testing -t mendersoftware/inventory:prtest .;
         ( ./tests/build-acceptance ./tests ./docs/management_api.yml ./docs/devices_api.yml &&

--- a/Dockerfile.acceptance-testing
+++ b/Dockerfile.acceptance-testing
@@ -3,8 +3,8 @@ FROM alpine:3.4
 EXPOSE 8080
 RUN mkdir /tests
 
-COPY ./inventory /usr/bin/
+COPY ./inventory-test /usr/bin/
 COPY ./config.yaml /usr/bin/
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["/usr/bin/inventory", "-test.coverprofile=/testing/coverage-acceptance.txt", "-acceptance-tests", "-test.run=TestRunMain", "-cli-args=server --automigrate"]
+ENTRYPOINT ["/usr/bin/inventory-test", "-test.coverprofile=/testing/coverage-acceptance.txt", "-acceptance-tests", "-test.run=TestRunMain", "-cli-args=server --automigrate"]


### PR DESCRIPTION
The binary built for acceptance tests is named `inventory` just like the main
'release' binary. This may cause confusion when testing manually. The patch
renames accepantce tests binary to `inventory-test` and updates both travis
script file and acceptance tests Dockerfile.

@mendersoftware/rndity @maciejmrowiec @GregorioDiStefano 