### PR TITLE
Allow filter with ":"

### DIFF
--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -147,19 +147,18 @@ func parseFilterParams(r *rest.Request) ([]store.Filter, error) {
 		}
 		valueStrArray := strings.Split(valueStr, queryParamValueSeparator)
 		filter = store.Filter{AttrName: name}
-		valueIdx := 0
 		if len(valueStrArray) == 2 {
-			valueIdx = 1
 			switch valueStrArray[filterEqOperatorIdx] {
 			case "eq":
 				filter.Operator = store.Eq
 			default:
 				return nil, errors.New("invalid filter operator")
 			}
+			filter.Value = valueStrArray[filterEqOperatorIdx+1]
 		} else {
 			filter.Operator = store.Eq
+			filter.Value = valueStr
 		}
-		filter.Value = valueStrArray[valueIdx]
 		floatValue, err := strconv.ParseFloat(filter.Value, 64)
 		if err == nil {
 			filter.ValueFloat = &floatValue


### PR DESCRIPTION
We couldn't filter attributes with ":" correctly.

For mac address "ff:ff:ff:ff:ff:ff" example, we will request with the query string like this: `attr_name1=ff:ff:ff:ff:ff:ff`, but actually the filter will be "ff" not "ff:ff:ff:ff:ff:ff".