### PR TITLE
travis: remove the 'backend integration' and 'trigger integration' st…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,24 +118,6 @@ jobs:
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F acceptance -f ./tests/coverage-acceptance.txt;
 
-    - stage: Tests
-      name: "backend-integration"
-      install:
-        - sudo apt-get -qq update
-        - pip3 install -U --user PyYAML
-      script:
-        - git clone -b master https://github.com/mendersoftware/integration.git;
-
-        - CGO_ENABLED=0 go build;
-        - sudo docker build -t mendersoftware/useradm:pr .;
-
-        - ./integration/extra/release_tool.py --set-version-of mender-useradm --version pr;
-        - PYTEST_ARGS="-k 'not Multitenant'" ./integration/backend-tests/run;
-
-    - stage: Trigger integration
-      script:
-        - echo "TODO trigger jenkins integration tests"
-
     - stage: Build and publish
       name: "dockerhub"
       if: type = push


### PR DESCRIPTION
…ages

first off - the backend section had a bug that prevented anything from building.
secondly - it's not useful anymore, so it's removed altogether.
same goes for 'trigger integration'.

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

spotted when reviewing a contribution