### PR TITLE
get total device count on dev-list request to allow leaner pagination in gui

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: go
 # Forces travis to use VM insted container, required to be able to build containers.
 sudo: required
 
+# Disable git shallow clone. We need full history for validating copyright year of each file.
+git:
+    depth: false
+
 services:
     - docker
     - mongodb

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Northern.tech AS
+Copyright 2019 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,7 +1,7 @@
 
 # These are identical to Apache-2.0 license.
 c773be5f6ca136ca7791e117829ff9a60b4a1436cc2bfa9214895f4ed9b3f2a9  COPYING
-98ed35b5a138f58164b5c0dbccd9d7f01ef4d84b9dba01e896f0a3241c50c0f7  LICENSE
+beb140be4cd64599bedc691a55b2729c9cc611a4b9d6ec44e01270105daf18a2  LICENSE
 98ed35b5a138f58164b5c0dbccd9d7f01ef4d84b9dba01e896f0a3241c50c0f7  vendor/github.com/mendersoftware/mendertesting/LICENSE
 9e015a4328bd336835c9969e38b1fc338a40bdea18d4d1f33b2cd12808238dd7  vendor/github.com/mendersoftware/go-lib-micro/LICENSE
 5e3400b93bbb099e83e52bab885e7441750673c21f97988ca3f1240639b63283  vendor/github.com/spf13/afero/LICENSE.txt

--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -204,34 +204,28 @@ func (i *inventoryHandlers) GetDevicesHandler(w rest.ResponseWriter, r *rest.Req
 		return
 	}
 
-	//get one extra device to see if there's a 'next' page
 	ld := store.ListQuery{int((page - 1) * perPage),
-		int(perPage + 1),
+		int(perPage),
 		filters,
 		sort,
 		hasGroup,
 		groupName}
 
-	devs, err := i.inventory.ListDevices(ctx, ld)
+	devs, totalCount, err := i.inventory.ListDevices(ctx, ld)
 
 	if err != nil {
 		u.RestErrWithLogInternal(w, r, l, err)
 		return
 	}
 
-	len := len(devs)
-	hasNext := false
-	if uint64(len) > perPage {
-		hasNext = true
-		len = int(perPage)
-	}
-
+	hasNext := totalCount > int(page * perPage)
 	links := utils.MakePageLinkHdrs(r, page, perPage, hasNext)
-
 	for _, l := range links {
 		w.Header().Add("Link", l)
 	}
-	w.WriteJson(devs[:len])
+	// the response writer will ensure the header name is in Kebab-Pascal-Case
+	w.Header().Add("X-Total-Count", strconv.Itoa(totalCount))
+	w.WriteJson(devs)
 }
 
 func (i *inventoryHandlers) GetDeviceHandler(w rest.ResponseWriter, r *rest.Request) {
@@ -395,7 +389,7 @@ func (i *inventoryHandlers) GetDevicesByGroup(w rest.ResponseWriter, r *rest.Req
 	}
 
 	//get one extra device to see if there's a 'next' page
-	ids, err := i.inventory.ListDevicesByGroup(ctx, model.GroupName(group), int((page-1)*perPage), int(perPage+1))
+	ids, totalCount, err := i.inventory.ListDevicesByGroup(ctx, model.GroupName(group), int((page-1)*perPage), int(perPage))
 	if err != nil {
 		if err == store.ErrGroupNotFound {
 			u.RestErrWithLog(w, r, l, err, http.StatusNotFound)
@@ -405,21 +399,15 @@ func (i *inventoryHandlers) GetDevicesByGroup(w rest.ResponseWriter, r *rest.Req
 		return
 	}
 
-	len := len(ids)
-	hasNext := false
-	if uint64(len) > perPage {
-		hasNext = true
-		len = int(perPage)
-	}
+	hasNext := totalCount > int(page * perPage)
 
 	links := utils.MakePageLinkHdrs(r, page, perPage, hasNext)
 	for _, l := range links {
 		w.Header().Add("Link", l)
 	}
-	count, err := i.inventory.GetDeviceCountByGroup(ctx, model.GroupName(group))
-	w.Header().Add("GroupCount", strconv.Itoa(count))
-	w.WriteJson(ids[:len])
-
+	// the response writer will ensure the header name is in Kebab-Pascal-Case
+	w.Header().Add("X-Total-Count", strconv.Itoa(totalCount))
+	w.WriteJson(ids)
 }
 
 func parseDevice(r *rest.Request) (*model.Device, error) {

--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -416,6 +416,8 @@ func (i *inventoryHandlers) GetDevicesByGroup(w rest.ResponseWriter, r *rest.Req
 	for _, l := range links {
 		w.Header().Add("Link", l)
 	}
+	count, err := i.inventory.GetDeviceCountByGroup(ctx, model.GroupName(group))
+	w.Header().Add("GroupCount", strconv.Itoa(count))
 	w.WriteJson(ids[:len])
 
 }

--- a/api/http/api_inventory_test.go
+++ b/api/http/api_inventory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -1080,6 +1080,11 @@ func TestApiInventoryGetDevicesByGroup(t *testing.T) {
 			mock.AnythingOfType("int"),
 			mock.AnythingOfType("int"),
 		).Return(mockListDeviceIDs(testCase.listDevicesNum), testCase.listDevicesErr)
+
+		inv.On("GetDeviceCountByGroup",
+			ctx,
+			mock.AnythingOfType("model.GroupName"),
+		).Return(testCase.listDevicesNum, testCase.listDevicesErr)
 
 		apih := makeMockApiHandler(t, &inv)
 

--- a/api/http/api_inventory_test.go
+++ b/api/http/api_inventory_test.go
@@ -162,15 +162,17 @@ func TestApiInventoryGetDevices(t *testing.T) {
 	rest.ErrorFieldName = "error"
 
 	testCases := map[string]struct {
-		listDevicesNum int
-		listDevicesErr error
-		inReq          *http.Request
-		resp           utils.JSONResponseParams
+		listDevicesNum  int
+		listDevicesErr  error
+		listDeviceTotal int
+		inReq           *http.Request
+		resp            utils.JSONResponseParams
 	}{
 		"get all devices in group": {
-			listDevicesNum: 3,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=4&per_page=5&group=foo", nil),
+			listDevicesNum:  3,
+			listDevicesErr:  nil,
+			listDeviceTotal: 18,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=4&per_page=5&group=foo", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     200,
 				OutputBodyObject: mockListDevices(3),
@@ -179,13 +181,15 @@ func TestApiInventoryGetDevices(t *testing.T) {
 						fmt.Sprintf(utils.LinkTmpl, "devices", "group=foo&page=3&per_page=5", "prev"),
 						fmt.Sprintf(utils.LinkTmpl, "devices", "group=foo&page=1&per_page=5", "first"),
 					},
+					"X-Total-Count": { "18" },
 				},
 			},
 		},
 		"valid pagination, no next page": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=4&per_page=5", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 20,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=4&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     200,
 				OutputBodyObject: mockListDevices(5),
@@ -194,13 +198,15 @@ func TestApiInventoryGetDevices(t *testing.T) {
 						fmt.Sprintf(utils.LinkTmpl, "devices", "page=3&per_page=5", "prev"),
 						fmt.Sprintf(utils.LinkTmpl, "devices", "page=1&per_page=5", "first"),
 					},
+					"X-Total-Count": { "20" },
 				},
 			},
 		},
 		"valid pagination, with next page": {
-			listDevicesNum: 9,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=4&per_page=5", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 21,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=4&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     200,
 				OutputBodyObject: mockListDevices(5),
@@ -209,13 +215,15 @@ func TestApiInventoryGetDevices(t *testing.T) {
 						fmt.Sprintf(utils.LinkTmpl, "devices", "page=3&per_page=5", "prev"),
 						fmt.Sprintf(utils.LinkTmpl, "devices", "page=1&per_page=5", "first"),
 					},
+					"X-Total-Count": { "21" },
 				},
 			},
 		},
 		"invalid pagination - page format": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=foo&per_page=5", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 5,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=foo&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     400,
 				OutputBodyObject: RestError(utils.MsgQueryParmInvalid("page")),
@@ -223,9 +231,10 @@ func TestApiInventoryGetDevices(t *testing.T) {
 			},
 		},
 		"invalid pagination - per_page format": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=foo", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 5,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=foo", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     400,
 				OutputBodyObject: RestError(utils.MsgQueryParmInvalid("per_page")),
@@ -233,9 +242,10 @@ func TestApiInventoryGetDevices(t *testing.T) {
 			},
 		},
 		"invalid pagination - bounds": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=0&per_page=5", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 5,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=0&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     400,
 				OutputBodyObject: RestError(utils.MsgQueryParmLimit("page")),
@@ -243,9 +253,10 @@ func TestApiInventoryGetDevices(t *testing.T) {
 			},
 		},
 		"valid attribute filter": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=qe:123:123:123", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 5,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=qe:123:123:123", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     200,
 				OutputBodyObject: mockListDevices(5),
@@ -253,13 +264,15 @@ func TestApiInventoryGetDevices(t *testing.T) {
 					"Link": {
 						fmt.Sprintf(utils.LinkTmpl, "devices", "attr_name1=qe%3A123%3A123%3A123&page=1&per_page=5", "first"),
 					},
+					"X-Total-Count": { "5" },
 				},
 			},
 		},
 		"invalid attribute filter operator": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=neq:123", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 5,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=neq:123", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     400,
 				OutputBodyObject: RestError("invalid filter operator"),
@@ -267,9 +280,10 @@ func TestApiInventoryGetDevices(t *testing.T) {
 			},
 		},
 		"valid sort order value": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?sort=attr_name1:asc&page=1&per_page=5", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 5,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?sort=attr_name1:asc&page=1&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     200,
 				OutputBodyObject: mockListDevices(5),
@@ -277,13 +291,15 @@ func TestApiInventoryGetDevices(t *testing.T) {
 					"Link": {
 						fmt.Sprintf(utils.LinkTmpl, "devices", "page=1&per_page=5&sort=attr_name1%3Aasc", "first"),
 					},
+					"X-Total-Count": { "5" },
 				},
 			},
 		},
 		"invalid sort order value": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&sort=attr_name1:gte", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 5,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&sort=attr_name1:gte", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     400,
 				OutputBodyObject: RestError("invalid sort order"),
@@ -291,9 +307,10 @@ func TestApiInventoryGetDevices(t *testing.T) {
 			},
 		},
 		"valid has_group": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?has_group=true&page=1&per_page=5", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 5,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?has_group=true&page=1&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     200,
 				OutputBodyObject: mockListDevices(5),
@@ -301,13 +318,15 @@ func TestApiInventoryGetDevices(t *testing.T) {
 					"Link": {
 						fmt.Sprintf(utils.LinkTmpl, "devices", "has_group=true&page=1&per_page=5", "first"),
 					},
+					"X-Total-Count": { "5" },
 				},
 			},
 		},
 		"invalid has_group": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&has_group=asd", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  nil,
+			listDeviceTotal: 5,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&has_group=asd", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     400,
 				OutputBodyObject: RestError(utils.MsgQueryParmInvalid("has_group")),
@@ -315,9 +334,10 @@ func TestApiInventoryGetDevices(t *testing.T) {
 			},
 		},
 		"inv.ListDevices error": {
-			listDevicesNum: 5,
-			listDevicesErr: errors.New("inventory error"),
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=4&per_page=5", nil),
+			listDevicesNum:  5,
+			listDevicesErr:  errors.New("inventory error"),
+			listDeviceTotal: 20,
+			inReq:           test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=4&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     500,
 				OutputBodyObject: RestError("internal error"),
@@ -335,7 +355,7 @@ func TestApiInventoryGetDevices(t *testing.T) {
 		inv.On("ListDevices",
 			ctx,
 			mock.AnythingOfType("store.ListQuery"),
-		).Return(mockListDevices(testCase.listDevicesNum), testCase.listDevicesErr)
+		).Return(mockListDevices(testCase.listDevicesNum), testCase.listDeviceTotal, testCase.listDevicesErr)
 
 		apih := makeMockApiHandler(t, &inv)
 
@@ -981,15 +1001,17 @@ func TestApiInventoryGetDevicesByGroup(t *testing.T) {
 	rest.ErrorFieldName = "error"
 
 	testCases := map[string]struct {
-		listDevicesNum int
-		listDevicesErr error
-		inReq          *http.Request
-		resp           utils.JSONResponseParams
+		listDevicesNum   int
+		listDevicesErr   error
+		listDevicesTotal int
+		inReq            *http.Request
+		resp             utils.JSONResponseParams
 	}{
 		"valid pagination, no next page": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=4&per_page=5", nil),
+			listDevicesNum:   5,
+			listDevicesErr:   nil,
+			listDevicesTotal: 20,
+			inReq:            test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=4&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     200,
 				OutputBodyObject: mockListDeviceIDs(5),
@@ -998,13 +1020,15 @@ func TestApiInventoryGetDevicesByGroup(t *testing.T) {
 						fmt.Sprintf(utils.LinkTmpl, "devices", "page=3&per_page=5", "prev"),
 						fmt.Sprintf(utils.LinkTmpl, "devices", "page=1&per_page=5", "first"),
 					},
+					"X-Total-Count": { "20" },
 				},
 			},
 		},
 		"valid pagination, with next page": {
-			listDevicesNum: 9,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=4&per_page=5", nil),
+			listDevicesNum:   5,
+			listDevicesErr:   nil,
+			listDevicesTotal: 21,
+			inReq:            test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=4&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     200,
 				OutputBodyObject: mockListDeviceIDs(5),
@@ -1013,13 +1037,15 @@ func TestApiInventoryGetDevicesByGroup(t *testing.T) {
 						fmt.Sprintf(utils.LinkTmpl, "devices", "page=3&per_page=5", "prev"),
 						fmt.Sprintf(utils.LinkTmpl, "devices", "page=1&per_page=5", "first"),
 					},
+					"X-Total-Count": { "21" },
 				},
 			},
 		},
 		"invalid pagination - page format": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=foo&per_page=5", nil),
+			listDevicesNum:   5,
+			listDevicesErr:   nil,
+			listDevicesTotal: 5,
+			inReq:            test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=foo&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     400,
 				OutputBodyObject: RestError(utils.MsgQueryParmInvalid("page")),
@@ -1027,9 +1053,10 @@ func TestApiInventoryGetDevicesByGroup(t *testing.T) {
 			},
 		},
 		"invalid pagination - per_page format": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=1&per_page=foo", nil),
+			listDevicesNum:   5,
+			listDevicesErr:   nil,
+			listDevicesTotal: 5,
+			inReq:            test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=1&per_page=foo", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     400,
 				OutputBodyObject: RestError(utils.MsgQueryParmInvalid("per_page")),
@@ -1037,9 +1064,10 @@ func TestApiInventoryGetDevicesByGroup(t *testing.T) {
 			},
 		},
 		"invalid pagination - bounds": {
-			listDevicesNum: 5,
-			listDevicesErr: nil,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=0&per_page=5", nil),
+			listDevicesNum:   5,
+			listDevicesErr:   nil,
+			listDevicesTotal: 5,
+			inReq:            test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=0&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     400,
 				OutputBodyObject: RestError(utils.MsgQueryParmLimit("page")),
@@ -1047,9 +1075,10 @@ func TestApiInventoryGetDevicesByGroup(t *testing.T) {
 			},
 		},
 		"inv.ListDevicesByGroup error - group not found": {
-			listDevicesNum: 5,
-			listDevicesErr: store.ErrGroupNotFound,
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=4&per_page=5", nil),
+			listDevicesNum:   5,
+			listDevicesErr:   store.ErrGroupNotFound,
+			listDevicesTotal: 20,
+			inReq:            test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=4&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     404,
 				OutputBodyObject: RestError("group not found"),
@@ -1057,9 +1086,10 @@ func TestApiInventoryGetDevicesByGroup(t *testing.T) {
 			},
 		},
 		"inv.ListDevicesByGroup error - internal": {
-			listDevicesNum: 5,
-			listDevicesErr: errors.New("inventory error"),
-			inReq:          test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=4&per_page=5", nil),
+			listDevicesNum:   5,
+			listDevicesErr:   errors.New("inventory error"),
+			listDevicesTotal: 20,
+			inReq:            test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/groups/foo/devices?page=4&per_page=5", nil),
 			resp: utils.JSONResponseParams{
 				OutputStatus:     500,
 				OutputBodyObject: RestError("internal error"),
@@ -1079,12 +1109,7 @@ func TestApiInventoryGetDevicesByGroup(t *testing.T) {
 			mock.AnythingOfType("model.GroupName"),
 			mock.AnythingOfType("int"),
 			mock.AnythingOfType("int"),
-		).Return(mockListDeviceIDs(testCase.listDevicesNum), testCase.listDevicesErr)
-
-		inv.On("GetDeviceCountByGroup",
-			ctx,
-			mock.AnythingOfType("model.GroupName"),
-		).Return(testCase.listDevicesNum, testCase.listDevicesErr)
+		).Return(mockListDeviceIDs(testCase.listDevicesNum), testCase.listDevicesTotal, testCase.listDevicesErr)
 
 		apih := makeMockApiHandler(t, &inv)
 

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -73,6 +73,11 @@ paths:
           description: If present, limits the results only to devices assigned/not assigned to a group.
           required: false
           type: boolean
+        - name: group
+          in: query
+          description: If present, limits the results only to devices belonging to the given group.
+          required: false
+          type: string
 
       responses:
         200:

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -84,6 +84,9 @@ paths:
                 Standard header, used for page navigation.
 
                 Supported relation types are 'first', 'next' and 'prev'.
+            X-Total-Count:
+              type: string
+              description: Custom header indicating the total number of devices for the given query parameters
           schema:
             title: ListOfDevices
             type: array
@@ -356,6 +359,9 @@ paths:
             Link:
               type: string
               description: Standard header, we support 'first', 'next', and 'prev'.
+            X-Total-Count:
+              type: string
+              description: Custom header indicating the total number of devices in the given group
           schema:
             title: ListOfIDs
             type: array

--- a/inv/inventory.go
+++ b/inv/inventory.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/inv/inventory.go
+++ b/inv/inventory.go
@@ -33,6 +33,7 @@ type InventoryApp interface {
 	UpdateDeviceGroup(ctx context.Context, id model.DeviceID, group model.GroupName) error
 	ListGroups(ctx context.Context) ([]model.GroupName, error)
 	ListDevicesByGroup(ctx context.Context, group model.GroupName, skip int, limit int) ([]model.DeviceID, error)
+	GetDeviceCountByGroup(ctx context.Context, group model.GroupName) (int, error)
 	GetDeviceGroup(ctx context.Context, id model.DeviceID) (model.GroupName, error)
 	DeleteDevice(ctx context.Context, id model.DeviceID) error
 	CreateTenant(ctx context.Context, tenant model.NewTenant) error
@@ -142,6 +143,19 @@ func (i *inventory) ListDevicesByGroup(ctx context.Context, group model.GroupNam
 	}
 
 	return ids, nil
+}
+
+func (i *inventory) GetDeviceCountByGroup(ctx context.Context, group model.GroupName) (int, error) {
+	count, err := i.db.GetDeviceCountByGroup(ctx, group)
+	if err != nil {
+		if err == store.ErrGroupNotFound {
+			return 0, err
+		} else {
+			return 0, errors.Wrap(err, "failed to get number of devices in group")
+		}
+	}
+
+	return count, nil
 }
 
 func (i *inventory) GetDeviceGroup(ctx context.Context, id model.DeviceID) (model.GroupName, error) {

--- a/inv/inventory.go
+++ b/inv/inventory.go
@@ -25,15 +25,14 @@ import (
 
 // this inventory service interface
 type InventoryApp interface {
-	ListDevices(ctx context.Context, q store.ListQuery) ([]model.Device, error)
+	ListDevices(ctx context.Context, q store.ListQuery) ([]model.Device, int, error)
 	GetDevice(ctx context.Context, id model.DeviceID) (*model.Device, error)
 	AddDevice(ctx context.Context, d *model.Device) error
 	UpsertAttributes(ctx context.Context, id model.DeviceID, attrs model.DeviceAttributes) error
 	UnsetDeviceGroup(ctx context.Context, id model.DeviceID, groupName model.GroupName) error
 	UpdateDeviceGroup(ctx context.Context, id model.DeviceID, group model.GroupName) error
 	ListGroups(ctx context.Context) ([]model.GroupName, error)
-	ListDevicesByGroup(ctx context.Context, group model.GroupName, skip int, limit int) ([]model.DeviceID, error)
-	GetDeviceCountByGroup(ctx context.Context, group model.GroupName) (int, error)
+	ListDevicesByGroup(ctx context.Context, group model.GroupName, skip int, limit int) ([]model.DeviceID, int, error)
 	GetDeviceGroup(ctx context.Context, id model.DeviceID) (model.GroupName, error)
 	DeleteDevice(ctx context.Context, id model.DeviceID) error
 	CreateTenant(ctx context.Context, tenant model.NewTenant) error
@@ -49,14 +48,14 @@ func NewInventory(d store.DataStore, tenantKeeper store.TenantDataKeeper,
 	return &inventory{db: d, tenantKeeper: tenantKeeper}
 }
 
-func (i *inventory) ListDevices(ctx context.Context, q store.ListQuery) ([]model.Device, error) {
-	devs, err := i.db.GetDevices(ctx, q)
+func (i *inventory) ListDevices(ctx context.Context, q store.ListQuery) ([]model.Device, int, error) {
+	devs, totalCount, err := i.db.GetDevices(ctx, q)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch devices")
+		return nil, -1, errors.Wrap(err, "failed to fetch devices")
 	}
 
-	return devs, nil
+	return devs, totalCount, nil
 }
 
 func (i *inventory) GetDevice(ctx context.Context, id model.DeviceID) (*model.Device, error) {
@@ -132,30 +131,17 @@ func (i *inventory) ListGroups(ctx context.Context) ([]model.GroupName, error) {
 	return groups, nil
 }
 
-func (i *inventory) ListDevicesByGroup(ctx context.Context, group model.GroupName, skip, limit int) ([]model.DeviceID, error) {
-	ids, err := i.db.GetDevicesByGroup(ctx, group, skip, limit)
+func (i *inventory) ListDevicesByGroup(ctx context.Context, group model.GroupName, skip, limit int) ([]model.DeviceID, int, error) {
+	ids, totalCount, err := i.db.GetDevicesByGroup(ctx, group, skip, limit)
 	if err != nil {
 		if err == store.ErrGroupNotFound {
-			return nil, err
+			return nil, -1, err
 		} else {
-			return nil, errors.Wrap(err, "failed to list devices by group")
+			return nil, -1, errors.Wrap(err, "failed to list devices by group")
 		}
 	}
 
-	return ids, nil
-}
-
-func (i *inventory) GetDeviceCountByGroup(ctx context.Context, group model.GroupName) (int, error) {
-	count, err := i.db.GetDeviceCountByGroup(ctx, group)
-	if err != nil {
-		if err == store.ErrGroupNotFound {
-			return 0, err
-		} else {
-			return 0, errors.Wrap(err, "failed to get number of devices in group")
-		}
-	}
-
-	return count, nil
+	return ids, totalCount, nil
 }
 
 func (i *inventory) GetDeviceGroup(ctx context.Context, id model.DeviceID) (model.GroupName, error) {

--- a/inv/inventory_test.go
+++ b/inv/inventory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ func TestInventoryListDevices(t *testing.T) {
 		datastoreError  error
 		outError        error
 		outDevices      []model.Device
+		outDeviceCount  int
 	}{
 		"has group nil": {
 			inHasGroup:      nil,
@@ -54,6 +55,7 @@ func TestInventoryListDevices(t *testing.T) {
 			datastoreError:  nil,
 			outError:        nil,
 			outDevices:      []model.Device{{ID: model.DeviceID("1")}},
+			outDeviceCount   1,
 		},
 		"has group true": {
 			inHasGroup:      boolPtr(true),
@@ -61,6 +63,7 @@ func TestInventoryListDevices(t *testing.T) {
 			datastoreError:  nil,
 			outError:        nil,
 			outDevices:      []model.Device{{ID: model.DeviceID("1"), Group: group}},
+			outDeviceCount   1,
 		},
 		"has group false": {
 			inHasGroup:      boolPtr(false),
@@ -68,6 +71,7 @@ func TestInventoryListDevices(t *testing.T) {
 			datastoreError:  nil,
 			outError:        nil,
 			outDevices:      []model.Device{{ID: model.DeviceID("1")}},
+			outDeviceCount   1,
 		},
 		"datastore error": {
 			inHasGroup:      nil,
@@ -75,6 +79,7 @@ func TestInventoryListDevices(t *testing.T) {
 			datastoreError:  errors.New("db connection failed"),
 			outError:        errors.New("failed to fetch devices: db connection failed"),
 			outDevices:      nil,
+			outDeviceCount   -1,
 		},
 		"get devices from group": {
 			group: "asd",
@@ -97,7 +102,7 @@ func TestInventoryListDevices(t *testing.T) {
 		).Return(tc.outDevices, tc.datastoreError)
 		i := invForTest(db)
 
-		devs, err := i.ListDevices(ctx, store.ListQuery{1, 10, nil, nil, tc.inHasGroup, tc.group})
+		devs, totalCount, err := i.ListDevices(ctx, store.ListQuery{1, 10, nil, nil, tc.inHasGroup, tc.group})
 
 		if tc.outError != nil {
 			if assert.Error(t, err) {
@@ -106,6 +111,7 @@ func TestInventoryListDevices(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 			assert.Equal(t, len(devs), len(tc.outDevices))
+			assert.Equal(t, totalCount, tc.outDeviceCount)
 		}
 	}
 }
@@ -415,6 +421,7 @@ func TestInventoryListDevicesByGroup(t *testing.T) {
 		DatastoreError error
 		OutError       string
 		OutDevices     []model.DeviceID
+		OutDeviceCount int
 	}{
 		"success": {
 			DatastoreError: nil,
@@ -424,21 +431,25 @@ func TestInventoryListDevicesByGroup(t *testing.T) {
 				model.DeviceID("2"),
 				model.DeviceID("3"),
 			},
+			OutDeviceCount 3,
 		},
 		"success - empty list": {
 			DatastoreError: nil,
 			OutError:       "",
 			OutDevices:     []model.DeviceID{},
+			OutDeviceCount  0,
 		},
 		"datastore error - group not found": {
 			DatastoreError: store.ErrGroupNotFound,
 			OutError:       "group not found",
 			OutDevices:     nil,
+			OutDeviceCount  -1,
 		},
 		"datastore error - generic": {
 			DatastoreError: errors.New("datastore error"),
 			OutError:       "failed to list devices by group: datastore error",
 			OutDevices:     nil,
+			OutDeviceCount  -1,
 		},
 	}
 
@@ -458,7 +469,7 @@ func TestInventoryListDevicesByGroup(t *testing.T) {
 
 		i := invForTest(db)
 
-		devs, err := i.ListDevicesByGroup(ctx, "foo", 1, 1)
+		devs, totalCount, err := i.ListDevicesByGroup(ctx, "foo", 1, 1)
 
 		if tc.OutError != "" {
 			if assert.Error(t, err) {
@@ -468,6 +479,9 @@ func TestInventoryListDevicesByGroup(t *testing.T) {
 			assert.NoError(t, err)
 			if !reflect.DeepEqual(tc.OutDevices, devs) {
 				assert.Fail(t, "expected: %v\nhave: %v", tc.OutDevices, devs)
+			}
+			if !reflect.DeepEqual(tc.OutDeviceCount, totalCount) {
+				assert.Fail(t, "expected: %v\nhave: %v", tc.OutDeviceCount, totalCount)
 			}
 		}
 	}

--- a/inv/inventory_test.go
+++ b/inv/inventory_test.go
@@ -55,7 +55,7 @@ func TestInventoryListDevices(t *testing.T) {
 			datastoreError:  nil,
 			outError:        nil,
 			outDevices:      []model.Device{{ID: model.DeviceID("1")}},
-			outDeviceCount   1,
+			outDeviceCount:  1,
 		},
 		"has group true": {
 			inHasGroup:      boolPtr(true),
@@ -63,7 +63,7 @@ func TestInventoryListDevices(t *testing.T) {
 			datastoreError:  nil,
 			outError:        nil,
 			outDevices:      []model.Device{{ID: model.DeviceID("1"), Group: group}},
-			outDeviceCount   1,
+			outDeviceCount:  1,
 		},
 		"has group false": {
 			inHasGroup:      boolPtr(false),
@@ -71,7 +71,7 @@ func TestInventoryListDevices(t *testing.T) {
 			datastoreError:  nil,
 			outError:        nil,
 			outDevices:      []model.Device{{ID: model.DeviceID("1")}},
-			outDeviceCount   1,
+			outDeviceCount:  1,
 		},
 		"datastore error": {
 			inHasGroup:      nil,
@@ -79,14 +79,15 @@ func TestInventoryListDevices(t *testing.T) {
 			datastoreError:  errors.New("db connection failed"),
 			outError:        errors.New("failed to fetch devices: db connection failed"),
 			outDevices:      nil,
-			outDeviceCount   -1,
+			outDeviceCount:  -1,
 		},
 		"get devices from group": {
-			group: "asd",
+			group:           "asd",
 			outDevices: []model.Device{
 				{ID: model.DeviceID("1"), Group: group},
 				{ID: model.DeviceID("2"), Group: group},
 			},
+			outDeviceCount:  2,
 		},
 	}
 
@@ -99,7 +100,7 @@ func TestInventoryListDevices(t *testing.T) {
 		db.On("GetDevices",
 			ctx,
 			mock.AnythingOfType("store.ListQuery"),
-		).Return(tc.outDevices, tc.datastoreError)
+		).Return(tc.outDevices, tc.outDeviceCount, tc.datastoreError)
 		i := invForTest(db)
 
 		devs, totalCount, err := i.ListDevices(ctx, store.ListQuery{1, 10, nil, nil, tc.inHasGroup, tc.group})
@@ -431,25 +432,25 @@ func TestInventoryListDevicesByGroup(t *testing.T) {
 				model.DeviceID("2"),
 				model.DeviceID("3"),
 			},
-			OutDeviceCount 3,
+			OutDeviceCount:3,
 		},
 		"success - empty list": {
 			DatastoreError: nil,
 			OutError:       "",
 			OutDevices:     []model.DeviceID{},
-			OutDeviceCount  0,
+			OutDeviceCount: 0,
 		},
 		"datastore error - group not found": {
 			DatastoreError: store.ErrGroupNotFound,
 			OutError:       "group not found",
 			OutDevices:     nil,
-			OutDeviceCount  -1,
+			OutDeviceCount: -1,
 		},
 		"datastore error - generic": {
 			DatastoreError: errors.New("datastore error"),
 			OutError:       "failed to list devices by group: datastore error",
 			OutDevices:     nil,
-			OutDeviceCount  -1,
+			OutDeviceCount: -1,
 		},
 	}
 
@@ -465,7 +466,7 @@ func TestInventoryListDevicesByGroup(t *testing.T) {
 			mock.AnythingOfType("model.GroupName"),
 			mock.AnythingOfType("int"),
 			mock.AnythingOfType("int"),
-		).Return(tc.OutDevices, tc.DatastoreError)
+		).Return(tc.OutDevices, tc.OutDeviceCount, tc.DatastoreError)
 
 		i := invForTest(db)
 
@@ -478,10 +479,10 @@ func TestInventoryListDevicesByGroup(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 			if !reflect.DeepEqual(tc.OutDevices, devs) {
-				assert.Fail(t, "expected: %v\nhave: %v", tc.OutDevices, devs)
+				assert.Fail(t, "expected outDevices to match", fmt.Sprintf("Expected: %v but\n have:%v", tc.OutDevices, devs))
 			}
 			if !reflect.DeepEqual(tc.OutDeviceCount, totalCount) {
-				assert.Fail(t, "expected: %v\nhave: %v", tc.OutDeviceCount, totalCount)
+				assert.Fail(t, "expected outDeviceCount to match", fmt.Sprintf("Expected: %v but\n have:%v", tc.OutDeviceCount, totalCount))
 			}
 		}
 	}

--- a/inv/mocks/InventoryApp.go
+++ b/inv/mocks/InventoryApp.go
@@ -124,7 +124,7 @@ func (_m *InventoryApp) ListDevices(ctx context.Context, q store.ListQuery) ([]m
 	}
 
 	var r1 int
-	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName, int, int) int); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, store.ListQuery) int); ok {
 		r1 = rf(ctx, q)
 	} else {
 		if ret.Get(1) != nil {

--- a/inv/mocks/InventoryApp.go
+++ b/inv/mocks/InventoryApp.go
@@ -111,7 +111,7 @@ func (_m *InventoryApp) GetDeviceGroup(ctx context.Context, id model.DeviceID) (
 }
 
 // ListDevices provides a mock function with given fields: ctx, q
-func (_m *InventoryApp) ListDevices(ctx context.Context, q store.ListQuery) ([]model.Device, error) {
+func (_m *InventoryApp) ListDevices(ctx context.Context, q store.ListQuery) ([]model.Device, int, error) {
 	ret := _m.Called(ctx, q)
 
 	var r0 []model.Device
@@ -123,18 +123,27 @@ func (_m *InventoryApp) ListDevices(ctx context.Context, q store.ListQuery) ([]m
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, store.ListQuery) error); ok {
+	var r1 int
+	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName, int, int) int); ok {
 		r1 = rf(ctx, q)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(int)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, store.ListQuery) error); ok {
+		r2 = rf(ctx, q)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // ListDevicesByGroup provides a mock function with given fields: ctx, group, skip, limit
-func (_m *InventoryApp) ListDevicesByGroup(ctx context.Context, group model.GroupName, skip int, limit int) ([]model.DeviceID, error) {
+func (_m *InventoryApp) ListDevicesByGroup(ctx context.Context, group model.GroupName, skip int, limit int) ([]model.DeviceID, int, error) {
 	ret := _m.Called(ctx, group, skip, limit)
 
 	var r0 []model.DeviceID
@@ -146,37 +155,24 @@ func (_m *InventoryApp) ListDevicesByGroup(ctx context.Context, group model.Grou
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName, int, int) error); ok {
+	var r1 int
+	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName, int, int) int); ok {
 		r1 = rf(ctx, group, skip, limit)
 	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// ListDevicesByGroup provides a mock function with given fields: ctx, group
-func (_m *InventoryApp) GetDeviceCountByGroup(ctx context.Context, group model.GroupName) (int, error) {
-	ret := _m.Called(ctx, group)
-
-	var r0 int
-	if rf, ok := ret.Get(0).(func(context.Context, model.GroupName) int); ok {
-		r0 = rf(ctx, group)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(int)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(int)
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName) error); ok {
-		r1 = rf(ctx, group)
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, model.GroupName, int, int) error); ok {
+		r2 = rf(ctx, group, skip, limit)
 	} else {
-		r1 = ret.Error(1)
+		r2 = ret.Error(2)
 	}
 
-	return r0, r1
+	return r0, r1, r2
 }
 
 // ListGroups provides a mock function with given fields: ctx

--- a/inv/mocks/InventoryApp.go
+++ b/inv/mocks/InventoryApp.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -149,6 +149,29 @@ func (_m *InventoryApp) ListDevicesByGroup(ctx context.Context, group model.Grou
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName, int, int) error); ok {
 		r1 = rf(ctx, group, skip, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListDevicesByGroup provides a mock function with given fields: ctx, group
+func (_m *InventoryApp) GetDeviceCountByGroup(ctx context.Context, group model.GroupName) (int, error) {
+	ret := _m.Called(ctx, group)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context, model.GroupName) int); ok {
+		r0 = rf(ctx, group)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(int)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName) error); ok {
+		r1 = rf(ctx, group)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -29,7 +29,7 @@ var (
 )
 
 type DataStore interface {
-	GetDevices(ctx context.Context, q ListQuery) ([]model.Device, error)
+	GetDevices(ctx context.Context, q ListQuery) ([]model.Device, int, error)
 
 	// find a device with given `id`, returns the device or nil,
 	// if device was not found, error and returned device are nil
@@ -60,10 +60,7 @@ type DataStore interface {
 	ListGroups(ctx context.Context) ([]model.GroupName, error)
 
 	// Lists devices belonging to a group
-	GetDevicesByGroup(ctx context.Context, group model.GroupName, skip, limit int) ([]model.DeviceID, error)
-
-	// Get number of devices belonging to a group
-	GetDeviceCountByGroup(ctx context.Context, group model.GroupName) (int, error)
+	GetDevicesByGroup(ctx context.Context, group model.GroupName, skip, limit int) ([]model.DeviceID, int, error)
 
 	// Get device's group
 	GetDeviceGroup(ctx context.Context, id model.DeviceID) (model.GroupName, error)

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -62,6 +62,9 @@ type DataStore interface {
 	// Lists devices belonging to a group
 	GetDevicesByGroup(ctx context.Context, group model.GroupName, skip, limit int) ([]model.DeviceID, error)
 
+	// Get number of devices belonging to a group
+	GetDeviceCountByGroup(ctx context.Context, group model.GroupName) (int, error)
+
 	// Get device's group
 	GetDeviceGroup(ctx context.Context, id model.DeviceID) (model.GroupName, error)
 }

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -134,6 +134,29 @@ func (_m *DataStore) GetDevicesByGroup(ctx context.Context, group model.GroupNam
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName, int, int) error); ok {
 		r1 = rf(ctx, group, skip, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListGroups provides a mock function with given fields: ctx, group
+func (_m *DataStore) GetDeviceCountByGroup(ctx context.Context, group model.GroupName) (int, error) {
+	ret := _m.Called(ctx, group)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context, model.GroupName) int); ok {
+		r0 = rf(ctx, group)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(int)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName) error); ok {
+		r1 = rf(ctx, group)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -96,7 +96,7 @@ func (_m *DataStore) GetDeviceGroup(ctx context.Context, id model.DeviceID) (mod
 }
 
 // GetDevices provides a mock function with given fields: ctx, q
-func (_m *DataStore) GetDevices(ctx context.Context, q store.ListQuery) ([]model.Device, error) {
+func (_m *DataStore) GetDevices(ctx context.Context, q store.ListQuery) ([]model.Device, int, error) {
 	ret := _m.Called(ctx, q)
 
 	var r0 []model.Device
@@ -108,18 +108,27 @@ func (_m *DataStore) GetDevices(ctx context.Context, q store.ListQuery) ([]model
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, store.ListQuery) error); ok {
+	var r1 int
+	if rf, ok := ret.Get(1).(func(context.Context, store.ListQuery) int); ok {
 		r1 = rf(ctx, q)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(int)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, store.ListQuery) error); ok {
+		r2 = rf(ctx, q)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // GetDevicesByGroup provides a mock function with given fields: ctx, group, skip, limit
-func (_m *DataStore) GetDevicesByGroup(ctx context.Context, group model.GroupName, skip int, limit int) ([]model.DeviceID, error) {
+func (_m *DataStore) GetDevicesByGroup(ctx context.Context, group model.GroupName, skip int, limit int) ([]model.DeviceID, int, error) {
 	ret := _m.Called(ctx, group, skip, limit)
 
 	var r0 []model.DeviceID
@@ -131,14 +140,23 @@ func (_m *DataStore) GetDevicesByGroup(ctx context.Context, group model.GroupNam
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName, int, int) error); ok {
+	var r1 int
+	if rf, ok := ret.Get(1).(func(context.Context, model.GroupName, int, int) int); ok {
 		r1 = rf(ctx, group, skip, limit)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(int)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, model.GroupName, int, int) error); ok {
+		r2 = rf(ctx, group, skip, limit)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // ListGroups provides a mock function with given fields: ctx, group

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -136,11 +136,10 @@ func NewDataStoreMongo(config DataStoreMongoConfig) (*DataStoreMongo, error) {
 	return db, nil
 }
 
-func (db *DataStoreMongo) GetDevices(ctx context.Context, q store.ListQuery) ([]model.Device, error) {
+func (db *DataStoreMongo) GetDevices(ctx context.Context, q store.ListQuery) ([]model.Device, int, error) {
 	s := db.session.Copy()
 	defer s.Close()
 	c := s.DB(mstore.DbFromContext(ctx, DbName)).C(DbDevicesColl)
-	res := []model.Device{}
 
 	queryFilters := make([]bson.M, 0)
 	for _, filter := range q.Filters {
@@ -158,40 +157,96 @@ func (db *DataStoreMongo) GetDevices(ctx context.Context, q store.ListQuery) ([]
 			}
 		}
 	}
-
-	if q.HasGroup != nil {
-		if *q.HasGroup {
-			queryFilters = append(queryFilters, bson.M{DbDevGroup: bson.M{"$exists": true}})
-		} else {
-			queryFilters = append(queryFilters, bson.M{DbDevGroup: bson.M{"$exists": false}})
-		}
-	}
-
-	if q.GroupName != "" {
-		queryFilters = append(queryFilters, bson.M{DbDevGroup: q.GroupName})
-	}
-
 	findQuery := bson.M{}
 	if len(queryFilters) > 0 {
 		findQuery["$and"] = queryFilters
 	}
+	groupFilter := bson.M{}
+	if q.GroupName != "" {
+		groupFilter = bson.M{ DbDevGroup: q.GroupName }
+	}
+	groupExistenceFilter := bson.M{}
+	if q.HasGroup != nil {
+		groupExistenceFilter = bson.M{ DbDevGroup: bson.M{ "$exists": *q.HasGroup } }
+	}
+	filter := bson.M{
+		"$match": bson.M{
+			"$and": []bson.M{
+				groupFilter,
+				groupExistenceFilter,
+				findQuery,
+			},
+		},
+	}
 
-	query := c.Find(findQuery).Skip(q.Skip).Limit(q.Limit)
+	// since the sorting step will have to be executable we have to use a noop here instead of just
+	// an empty query object, as unsorted queries would fail otherwise
+	sortQuery := bson.M{ "$skip": 0 }
 	if q.Sort != nil {
 		sortField := fmt.Sprintf("%s.%s.%s", DbDevAttributes, q.Sort.AttrName, DbDevAttributesValue)
-		if q.Sort.Ascending {
-			query.Sort(sortField)
-		} else {
-			query.Sort("-" + sortField)
+		sortFieldQuery := bson.M{}
+		sortFieldQuery[sortField] = 1
+		if !q.Sort.Ascending {
+			sortFieldQuery[sortField] = -1
 		}
+		sortQuery = bson.M{ "$sort": sortFieldQuery }
 	}
+	limitQuery := bson.M{ "$skip": 0 }
+	// exchange the limit query only if limit is set, as limits need to be positive in an aggregation pipeline
+	if q.Limit > 0 {
+		limitQuery = bson.M{ "$limit": q.Limit }
+	}
+	combinedQuery := bson.M{
+		"$facet": bson.M{
+			"results": []bson.M{
+				sortQuery,
+				bson.M{ "$skip": q.Skip },
+				limitQuery,
+			},
+			"totalCount": []bson.M{
+				bson.M{ "$count": "count" },
+			},
+		},
+	}
+	resultMap := bson.M{
+		"$project": bson.M{
+			"results": 1,
+			"totalCount": bson.M{
+				"$ifNull": []interface{}{
+					bson.M{
+						"$arrayElemAt": []interface{}{ "$totalCount.count", 0 },
+					},
+					0,
+				},
+			},
+		},
+	}
+	// filter devices - skip, limit + get count afterwards
+	// followed by pretty printing
+	pipe := c.Pipe([]bson.M{
+		filter,
+		combinedQuery,
+		resultMap,
+	})
 
-	err := query.All(&res)
+	var res bson.M
+	err := pipe.One(&res)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch device list")
+		return nil, -1, errors.Wrap(err, "failed to fetch device list")
 	}
-
-	return res, nil
+	count := res["totalCount"].(int)
+	results := res["results"].([]interface{})
+	devices := make([]model.Device, len(results))
+	for i, d := range results {
+		var device model.Device
+		bsonBytes, e := bson.Marshal(d.(bson.M))
+		if e != nil {
+			return nil, count, errors.Wrap(e, "failed to parse device in device list")
+		}
+		bson.Unmarshal(bsonBytes, &device)
+		devices[i] = device
+	}
+	return devices, count, nil
 }
 
 func (db *DataStoreMongo) GetDevice(ctx context.Context, id model.DeviceID) (*model.Device, error) {
@@ -339,69 +394,35 @@ func (db *DataStoreMongo) ListGroups(ctx context.Context) ([]model.GroupName, er
 	return groups, nil
 }
 
-func (db *DataStoreMongo) GetDevicesByGroup(ctx context.Context, group model.GroupName, skip, limit int) ([]model.DeviceID, error) {
+func (db *DataStoreMongo) GetDevicesByGroup(ctx context.Context, group model.GroupName, skip, limit int) ([]model.DeviceID, int, error) {
 	s := db.session.Copy()
 	defer s.Close()
+	// compose aggregation pipeline
 	c := s.DB(mstore.DbFromContext(ctx, DbName)).C(DbDevicesColl)
-
-	filter := bson.M{DbDevGroup: group}
-
+	
 	//first, find if the group exists at all, i.e. if any dev is assigned
 	var dev model.Device
+	filter := bson.M{DbDevGroup: group}
 	err := c.Find(filter).One(&dev)
 	if err != nil {
 		if err == mgo.ErrNotFound {
-			return nil, store.ErrGroupNotFound
+			return nil, -1, store.ErrGroupNotFound
 		} else {
-			return nil, errors.Wrap(err, "failed to get devices for group")
+			return nil, -1, errors.Wrap(err, "failed to get a single device for group")
 		}
 	}
 
-	res := []model.Device{}
-
-	//get group's devices; select only the '_id' field
-	err = c.Find(filter).Select(bson.M{"_id": 1}).Skip(skip).Limit(limit).Sort("_id").All(&res)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get devices for group")
+	hasGroup := group != ""
+	devices, totalDevices, e := db.GetDevices(ctx, store.ListQuery{skip, limit, nil, nil, &hasGroup, string(group)})
+	if e != nil {
+		return nil, -1, errors.Wrap(e, "failed to get device list for group")
 	}
 
-	resIds := make([]model.DeviceID, len(res))
-	for i, d := range res {
+	resIds := make([]model.DeviceID, len(devices))
+	for i, d := range devices {
 		resIds[i] = d.ID
 	}
-
-	return resIds, nil
-}
-
-func (db *DataStoreMongo) GetDeviceCountByGroup(ctx context.Context, group model.GroupName) (int, error) {
-	s := db.session.Copy()
-	defer s.Close()
-
-	// compose aggregation pipeline
-	c := s.DB(mstore.DbFromContext(ctx, DbName)).C(DbDevicesColl)
-
-	filt := bson.M{"$match": bson.M{ "group": group }}
-	// the sortByCount might also be useful to return counts for all groups in one call, here it is
-	// used as a convenient way to get counts and structure, while still being one simple call in the
-	// pipeline
-	grp := bson.M{ "$sortByCount": "$group" }
-	
-	var resp bson.M
-
-	// first filter for devices out of current group, get count afterwards
-	pipe := c.Pipe([]bson.M{ filt, grp })
-	err := pipe.One(&resp)
-
-	switch err {
-	case nil:
-		break
-	case mgo.ErrNotFound:
-		return 0, store.ErrGroupNotFound
-	default:
-		return 0, err
-	}
-
-	return resp["count"].(int), err
+	return resIds, totalDevices, nil
 }
 
 func (db *DataStoreMongo) GetDeviceGroup(ctx context.Context, id model.DeviceID) (model.GroupName, error) {

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -15,6 +15,7 @@ package mongo_test
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -1573,7 +1574,7 @@ func TestGetDevicesByGroup(t *testing.T) {
 			InputSkip:         0,
 			InputLimit:        0,
 			OutputDevices:     nil,
-			OutputDeviceCount: -1
+			OutputDeviceCount: -1,
 			OutputError:       store.ErrGroupNotFound,
 		},
 		"dev group": {


### PR DESCRIPTION
the additional cost per request is most likely set off by the removed requirement for multiple requests to get all the devices per group, that are currently fired every time another group is selected in the ui...

Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>