### PR TITLE
[POC/DON'T MERGE] regex inventory search

### DIFF
--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -157,17 +157,27 @@ func parseFilterParams(r *rest.Request) ([]store.Filter, error) {
 			switch valueStrArray[filterEqOperatorIdx] {
 			case "eq":
 				filter.Operator = store.Eq
+			case "regex":
+				filter.Operator = store.Regex
 			default:
 				return nil, errors.New("invalid filter operator")
 			}
 			filter.Value = valueStrArray[filterEqOperatorIdx+1]
+		} else if strings.HasPrefix(valueStrArray[0], "~") {
+			// regex
+			filter.Operator = store.Regex
+			filter.Value = valueStrArray[0][1:]
 		} else {
+			// generic 'eq' search
 			filter.Operator = store.Eq
 			filter.Value = valueStr
 		}
-		floatValue, err := strconv.ParseFloat(filter.Value, 64)
-		if err == nil {
-			filter.ValueFloat = &floatValue
+		// only parse floats if we're not in regex
+		if filter.Operator != store.Regex {
+			floatValue, err := strconv.ParseFloat(filter.Value, 64)
+			if err == nil {
+				filter.ValueFloat = &floatValue
+			}
 		}
 
 		filters = append(filters, filter)

--- a/api/http/api_inventory_test.go
+++ b/api/http/api_inventory_test.go
@@ -130,11 +130,12 @@ func TestApiParseFilterParams(t *testing.T) {
 		},
 		"valid filter with multiple colons and ignore known operator": {
 			inReq:  test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=eq:qe:123:123:123", nil),
-			filter: "eq:qe:123:123:123",
+			filter: "qe:123:123:123",
 		},
+		/* no more invalid filters - they may simply be parts of valid values
 		"invalid filter with colon": {
 			inReq: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=qe:123", nil),
-		},
+		}, */
 		"valid filter with colon": {
 			inReq:  test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=eq:123", nil),
 			filter: "123",
@@ -268,6 +269,7 @@ func TestApiInventoryGetDevices(t *testing.T) {
 				},
 			},
 		},
+		/* no more invalid filters - they may simply be parts of valid values
 		"invalid attribute filter operator": {
 			listDevicesNum:  5,
 			listDevicesErr:  nil,
@@ -278,7 +280,7 @@ func TestApiInventoryGetDevices(t *testing.T) {
 				OutputBodyObject: RestError("invalid filter operator"),
 				OutputHeaders:    nil,
 			},
-		},
+		},*/
 		"valid sort order value": {
 			listDevicesNum:  5,
 			listDevicesErr:  nil,

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -338,6 +338,8 @@ func mongoOperator(co store.ComparisonOperator) string {
 	switch co {
 	case store.Eq:
 		return "$eq"
+	case store.Regex:
+		return "$regex"
 	}
 	return ""
 }

--- a/store/query.go
+++ b/store/query.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/store/query.go
+++ b/store/query.go
@@ -17,6 +17,7 @@ type ComparisonOperator int
 
 const (
 	Eq ComparisonOperator = 1 << iota
+	Regex
 )
 
 type Filter struct {

--- a/tests/REGEX_BENCHMARKING.md
+++ b/tests/REGEX_BENCHMARKING.md
@@ -1,0 +1,94 @@
+This documents a simple microbenchmark created for the regex search functionality. The aim is to see if a naive
+implementation will take us anywhere. It assumes no indexes, because we're not sure yet if they're feasible
+(hard limit per collection, need data type management - must not conflict; need to be created on the fly for
+new fields)
+
+Benchmarking is done indirectly, via http benchmarking (instead of db-level benchmarking). This is because of 
+some awkwardness of mongo perf testing tools (need js scripting, and/or old python, and/or done via mongo shell...) - 
+no time to figure it out for this POC. The tool of choice is https://github.com/codesenberg/bombardier.
+
+The benchmark metrics are:
+- latency(ms)
+- req/s
+
+Variables:
+- number of devices (1-5000)
+- number of attributes per device (1, 5, 10)
+- regex query:
+    - prefix (`^A1`)
+        - will find only anchored values like `A1_foo`
+        - the simplest query
+    - mac
+        - anchored MAC regex (`^$`)
+    - infix (`A1`)
+        - will find `A1` anywhere, more demanding (full scan)
+    - all queries on a single field
+- number of concurrent connections
+    - 10 - 100, in select cases up to 1000
+
+For each request, sampling is done over 10k requests total.
+
+# Disclaimer
+The benchmarks are of course naive - local dev laptop, single tenant db and some simple patterns.
+There are multiple moving parts that can affect production:
+- actual traffic
+- data distribution (num devs/num attrs)
+- actual queries (we're giving users a potential DoS weapon)
+- perf characteristics of our mongo provider
+- stuff like page/cache trashing (e.g. between tenants - how is memory used between dbs).
+
+IMO this can't be guessed. If we go with this solution, the only way is to monitor inventory
+and its db for long queries, and go from there (commit to a different solution altogether if necessary).
+
+# How to run
+Note that benchmarks run on *your* machine, not in docker.
+
+Requires:
+1. go 1.11 + bombardier: 
+`go get -u github.com/codesenberg/bombardier`
+
+2. `pip3 install pymongo`
+
+3. mongodb running (defaults)
+
+4. running inventory:
+`INVENTORY_MONGO=localhost:27017 inventory server --automigrate` 
+
+To run a benchmark:
+`cd tests && ./benchmark.py <name_of_benchmark> -c <num_connections>`
+
+Benchmarks are predefined in the 'benchmarks' dict.
+
+# Results
+Full results are available as a calc sheet at https://docs.google.com/spreadsheets/d/1ZuAWO3ymPx994vFIKmAJE7UUTj_x1unBYszgy879tZI/edit?usp=sharing.
+
+## Discussion
+Let's assume some limits/rules of thumb we're aiming at; these are based on different numbers floating
+around the net. It's a very open question as to what the numbers should be:
+
+- latency: 100-200ms
+    - 100ms quoted as 'max comfortable' latency for an actual human user
+    - let's make 200ms a stretch value
+    - twitter(2008): 200ms
+
+- req/s: 100?
+    - stackexachange(2013): 1700
+    - twitter(2008) had 200-300
+    - slashdot effect said to be(2006): 25-50, but that's pretty old
+
+We seem to be ok on the req/s front, they're always a good couple hundred (breaking point is
+at 1k concurrent connections, 5k devs with 10 attr each).
+
+The limiting factor seems to be the latency, and the target range is exceeded at around:
+- 5k devs
+- 5-10 attributes
+- 100 connections
+
+Assuming an average device with 10 attributes, the metrics are decent for the 1k device range.
+For the most risky query, the infix, we can go up to almost 500 connections.
+
+I don't want to draw too many conclusions from this, but it seems like:
+- for a couple hundred devices
+- with an average ~10 attributes
+- we should be ok up to a couple hundred connections
+- esp. if we limit the queries to prefix

--- a/tests/REGEX_BENCHMARKING.md
+++ b/tests/REGEX_BENCHMARKING.md
@@ -1,27 +1,28 @@
-This documents a simple microbenchmark created for the regex search functionality. The aim is to see if a naive
-implementation will take us anywhere. It assumes no indexes, because we're not sure yet if they're feasible
-(hard limit per collection, need data type management - must not conflict; need to be created on the fly for
-new fields)
+This documents a simple microbenchmark created for the regex search functionality. 
+The aim is to get a general feel of how far regexes can take us performance-wise.
 
-Benchmarking is done indirectly, via http benchmarking (instead of db-level benchmarking). This is because of 
+The regex search functionality is POC'ed in the service code in this branch.
+
+Benchmarking is done indirectly, via http benchmarking of the search endpoint (instead of db-level benchmarking). This is because of 
 some awkwardness of mongo perf testing tools (need js scripting, and/or old python, and/or done via mongo shell...) - 
 no time to figure it out for this POC. The tool of choice is https://github.com/codesenberg/bombardier.
 
-The benchmark metrics are:
+Benchmark collected metrics:
 - latency(ms)
 - req/s
 
-Variables:
-- number of devices (1-5000)
+Benchmark variables:
+- number of devices (10 to 100k's in select cases)
 - number of attributes per device (1, 5, 10)
 - regex query:
     - prefix (`^A1`)
         - will find only anchored values like `A1_foo`
         - the simplest query
-    - mac
-        - anchored MAC regex (`^$`)
     - infix (`A1`)
         - will find `A1` anywhere, more demanding (full scan)
+    - mac
+        - anchored MAC regex (`^...$`)
+        - = 'an actual regex', pretty demanding (good amt of matching + a terminating anchor)
     - all queries on a single field
 - number of concurrent connections
     - 10 - 100, in select cases up to 1000
@@ -35,7 +36,7 @@ There are multiple moving parts that can affect production:
 - data distribution (num devs/num attrs)
 - actual queries (we're giving users a potential DoS weapon)
 - perf characteristics of our mongo provider
-- stuff like page/cache trashing (e.g. between tenants - how is memory used between dbs).
+- stuff like page/cache thrashing (e.g. between tenants - how is memory used between dbs).
 
 IMO this can't be guessed. If we go with this solution, the only way is to monitor inventory
 and its db for long queries, and go from there (commit to a different solution altogether if necessary).
@@ -57,7 +58,7 @@ Requires:
 To run a benchmark:
 `cd tests && ./benchmark.py <name_of_benchmark> -c <num_connections>`
 
-Benchmarks are predefined in the 'benchmarks' dict.
+Benchmarks are predefined in the 'benchmarks' dict. 
 
 # Results
 
@@ -65,14 +66,17 @@ Full results are available as a calc sheet at https://docs.google.com/spreadshee
 
 There were 2 runs of the benchmark:
 - without indexes
-    - tested because of some limitiations of indexes (limited number; work only for anchored queries)
+    - tested because of some limitiations of indexes 
     - good to know the absolute worst case
 - with indexes
     - after some discussions re: bad performance of no indexes
 
-## Discussion
+IMPORTANT: the first sets of data were collected with a slightly buggy benchmark - sheet simple-noindex.
+Some runs were repeated after the fix - sheet FIXED-simple-noindex.
+I'm leaving the buggy results in, because they have an almost perfect x2 relation to the 'fixed' values.
+For the sake of time I'm not repeating all those runs, so just use the initial vals as a reference.
 
-### Run 1 - No indexing
+## Discussion
 Let's assume some limits/rules of thumb we're aiming at; these are based on different numbers floating
 around the net. It's a very open question as to what the numbers should be:
 
@@ -81,49 +85,56 @@ around the net. It's a very open question as to what the numbers should be:
     - let's make 200ms a stretch value
     - twitter(2008): 200ms
 
-- req/s: 100?
-    - stackexachange(2013): 1700
-    - twitter(2008) had 200-300
-    - slashdot effect said to be(2006): 25-50, but that's pretty old
+- req/s: max low hundreds?
+    - stackexachange(2013): 300
+    - twitter(2008): 600
 
-We seem to be ok on the req/s front, they're always a good couple hundred (breaking point is
-at 1k concurrent connections, 5k devs with 10 attr each).
+As for number of concurrently supported connections, this is very case by case. 
+In general, X users perform N daily visits of length L - some hits will be to the search EP, 
+and some will be concurrent. There are tricks to estimate this based on known user scenarios, 
+but we decided to settle for a ~10 guestimate.
 
-The limiting factor seems to be the latency, and the target range is exceeded at around:
-- 5k devs
-- 5-10 attributes
-- 100 connections
+### Run 1 - No indexing
 
-Assuming an average device with 10 attributes, the metrics are decent for the 1k device range.
-For the most risky query, the infix, we can go up to almost 500 connections.
-
-I don't want to draw too many conclusions from this, but it seems like:
-- for a couple hundred devices
-- with an average ~10 attributes
-- we should be ok up to a couple hundred connections
-- esp. if we limit the queries to prefix
+We can go up to as many as 50k (10 attrs) devices with comfortable latencies at max 10 concurrent connections.
+Near 50 concurrent connections the latencies break down.
 
 ### Run 2 - with indexing
-We decided that the above doesn't cut it in terms of performance.
+We decided the indexing is worth pursuing still, even despite the limitations.
 
-A second run was prepared:
-- this time with indexes
-- indexes work for anchored queries only so prefix and mac queries were tested
-- we went straight for a larger number of devices - from 5000 to 200000
-- 1, 10, and 100 concurrent connections were tested
-    - we decided that maybe the used connection count was a bit much, and we should focus at around 10
+Indexes work for anchored queries only so prefix and mac queries were tested
 
-The results at at sheet #2 of the calc linked above, and are extremely promising:
+We went straight for a larger number of devices - from 5000 to 200000, i.e. pick up where we left off
+with unindexed queries.
 
-- even at 200k devices, queries run well below 100ms
-- at 1-10 concurrent connections the time is simply close to 0 
-    - most of it is spent serializing the request probably
+The results at at sheet #2 of the calc linked above, and are promising.
 
-So, indexed anchored queries are extremely fast. Part of it is that the index easily fits into memory.
-At 200k, the index size is only 4mb - so not only does the index itself speed up the query, but the fact
-that the whole index search go over ram, not disk.
+As expected, the prefix query is improved immensely, with hardly any latency at even 200k(10 attr) devices; that's
+at 10 connections, but up to 10-100 concurrent connections are not a problem. The reason is that a prefix
+search is *the* case that tree-based indexes are meant to solve.
 
-We can conclude that millions of devices can be handled this way - 1mil = only 20mb...
+This was not the case for the 'mac' query - the performance even degraded slightly.
+The reason is that it's a very broad query, with no effective prefix to hang on to. As a result,
+with e.g. 10k devices - the db engine has to examine 10k index keys to find our 10 devices; then fetch them.
+For comparison, in the prefix case - only 11 keys have to be examined.
+So, the index here adds only some overhead to a dumb scan.
+
+Still, the numbers are satisfactory at 10 connections and 50k devices, and only fall off dramatically at 100 connections.
+
+To conclude:
+The results are promising for our guestimated number of concurrent connections(10), but not many more (50 seems the limit).
+
+Under that assumption, both non-indexed and indexed regexes perform ok up to 50k 'typical' devices.
+
+Indexes are worth pursuing, as for cases they're designed for (prefix) they boost performance considerably.
+
+Prefix queries should be favored or enforced, as for queries that are too open - performance is unpredictable and indexes don't help.
+
+Results have to be taken with a grain of salt given the contrived nature of the microbenchmark.
+
+These estimates will not substitute performance monitoring and reacting to issues on the fly.
+
+# Misc notes
 
 The risks of indexing:
 - they run out at 64 indexes

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -36,19 +36,20 @@ def _do_simple_attr(ndevs, nmatching, nattrs, where, index=False):
 
     devs = []
     for _ in range(ndevs):
+        attrs={}
         if nmatching > 0:
             if where == 'prefix':
-                d = dev({'sn': 'A1{}'.format(rstr(8))})
+                attrs['sn'] = 'A1{}'.format(rstr(8))
             elif where == 'infix':
-                d = dev({'sn': '{}A1{}'.format(rstr(4), rstr(4))})
+                attrs['sn'] = '{}A1{}'.format(rstr(4), rstr(4))
             nmatching -= 1
         else:
-            d = dev({'sn': '{}'.format(rstr(10))})
+            attrs['sn'] = '{}'.format(rstr(10))
 
         for i in range(nattrs-1):
-            d['foo{}'.format(i)] = '{}'.format(rstr(10))
+            attrs['foo{}'.format(i)] = '{}'.format(rstr(10))
 
-        devs.append(d)
+        devs.append(dev(attrs))
 
     mongo.inventory.devices.insert_many(devs)
     if index:
@@ -71,16 +72,17 @@ def _do_simple_attr_mac(ndevs, nmatching, nattrs, index=False):
 
     devs = []
     for _ in range(ndevs):
+        attrs={}
         if nmatching > 0:
-            d = dev({'mac': "02:00:00:%02x:%02x:%02x" % (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))})
+            attrs['mac'] = "02:00:00:%02x:%02x:%02x" % (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))
             nmatching -= 1
         else:
-            d = dev({'foo': '{}'.format(rstr(10))})
+            attrs['mac'] = '{}'.format(rstr(10))
 
         for i in range(nattrs-1):
-            d['foo{}'.format(i)] = '{}'.format(rstr(10))
+            attrs['foo{}'.format(i)] = '{}'.format(rstr(10))
 
-        devs.append(d)
+        devs.append(dev(attrs))
 
     mongo.inventory.devices.insert_many(devs)
     if index:
@@ -152,8 +154,9 @@ benchmarks = {
     '10_attr_5000_devs_mac': lambda : _do_simple_attr_mac(5000, 10, 10),
     '10_attr_10000_devs_mac': lambda : _do_simple_attr_mac(10000, 10, 10),
     '10_attr_20000_devs_mac': lambda : _do_simple_attr_mac(20000, 10, 10),
+    '10_attr_50000_devs_mac': lambda : _do_simple_attr_mac(50000, 10, 10),
     '10_attr_100000_devs_mac': lambda : _do_simple_attr_mac(100000, 10, 10),
-    '10_attr_200000_devs_mac': lambda : _do_simple_attr_mac(100000, 10, 10),
+    '10_attr_200000_devs_mac': lambda : _do_simple_attr_mac(200000, 10, 10),
     '10_attr_5000_devs_mac_index': lambda : _do_simple_attr_mac(5000, 10, 10, index=True),
     '10_attr_10000_devs_mac_index': lambda : _do_simple_attr_mac(10000, 10, 10, index=True),
     '10_attr_20000_devs_mac_index': lambda : _do_simple_attr_mac(20000, 10, 10, index=True),

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+import argparse
+import random
+import subprocess
+import os
+
+from pymongo import MongoClient
+
+from generate import rstr, rstrarr, rnum, rnumarr, rstrgen, dev
+
+URL='http://localhost:8080/api/0.1.0/devices?'
+mongo = None
+
+def run(bench, c='100', n='10000'):
+    query = bench()
+    url = with_qs(URL, query) 
+    subprocess.run(
+        [os.getenv('GOPATH')+'/bin/bombardier',
+        '-c', c,
+        '-n', n,
+        url])
+
+def with_qs(url, qs):
+    for q in qs:
+        url += '{}={}&'.format(q, qs[q])
+    return url
+
+# bench funcs return test query dict
+def _do_simple_attr(ndevs, nmatching, nattrs, where):
+    ''' generate ndevs devices, of which there will be nmatches (pattern 'A1', where = [prefix|infix]), 
+        each dev has a total of nattrs attributes
+    '''
+    print('benchmark=simple attr, ndevs={}, nmatching={}, nattrs={}, where={}'.format(ndevs, nmatching, nattrs, where))
+    global mongo
+
+    devs = []
+    for _ in range(ndevs):
+        if nmatching > 0:
+            if where == 'prefix':
+                d = dev({'sn': '^A1{}'.format(rstr(8))})
+            elif where == 'infix':
+                d = dev({'sn': '{}A1{}'.format(rstr(4), rstr(4))})
+            nmatching -= 1
+        else:
+            d = dev({'sn': '{}'.format(rstr(10))})
+
+        for i in range(nattrs-1):
+            d['foo{}'.format(i)] = '{}'.format(rstr(10))
+
+        devs.append(d)
+
+    mongo.inventory.devices.insert_many(devs)
+
+    assert mongo.inventory.devices.find({'devices.sn.value':{'$regex':'A1'}}).count() == nmatching 
+
+    if where == 'prefix':
+        return {'sn': '~^A1'}
+    else:
+        return {'sn': '~A1'}
+
+def _do_simple_attr_mac(ndevs, nmatching, nattrs):
+    ''' like _do_simple_attr, but the matching attribute is a mac,
+        and the query is a not so trivial regex
+    '''
+    print('benchmark=simple attrmac, ndevs={}, nmatching={}, nattrs={}'.format(ndevs, nmatching, nattrs))
+
+    global mongo
+
+    devs = []
+    for _ in range(ndevs):
+        if nmatching > 0:
+            d = dev({'mac': "02:00:00:%02x:%02x:%02x" % (random.randint(0, 255), random.randint(0, 255), random.randint(0, 255))})
+            nmatching -= 1
+        else:
+            d = dev({'foo': '{}'.format(rstr(10))})
+
+        for i in range(nattrs-1):
+            d['foo{}'.format(i)] = '{}'.format(rstr(10))
+
+        devs.append(d)
+
+    mongo.inventory.devices.insert_many(devs)
+
+    assert mongo.inventory.devices.find({'devices.mac.value':{'$regex':'^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$'}}).count() == nmatching
+    return {'mac': '~^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$'}
+
+benchmarks = {
+    '1_attr_10_devs_prefix': lambda : _do_simple_attr(10, 10, 1, 'prefix'),
+    '1_attr_100_devs_prefix': lambda : _do_simple_attr(100, 10, 1, 'prefix'),
+    '1_attr_500_devs_prefix': lambda : _do_simple_attr(500, 10, 1, 'prefix'),
+    '1_attr_1000_devs_prefix': lambda : _do_simple_attr(1000, 10, 1, 'prefix'),
+    '1_attr_5000_devs_prefix': lambda : _do_simple_attr(5000, 10, 1, 'prefix'),
+    '5_attr_10_devs_prefix': lambda : _do_simple_attr(10, 10, 5, 'prefix'),
+    '5_attr_100_devs_prefix': lambda : _do_simple_attr(100, 10, 5, 'prefix'),
+    '5_attr_500_devs_prefix': lambda : _do_simple_attr(500, 10, 5, 'prefix'),
+    '5_attr_1000_devs_prefix': lambda : _do_simple_attr(1000, 10, 5, 'prefix'),
+    '5_attr_5000_devs_prefix': lambda : _do_simple_attr(5000, 10, 5, 'prefix'),
+    '10_attr_10_devs_prefix': lambda : _do_simple_attr(10, 10, 10, 'prefix'),
+    '10_attr_100_devs_prefix': lambda : _do_simple_attr(100, 10, 10, 'prefix'),
+    '10_attr_500_devs_prefix': lambda : _do_simple_attr(500, 10, 10, 'prefix'),
+    '10_attr_1000_devs_prefix': lambda : _do_simple_attr(1000, 10, 10, 'prefix'),
+    '10_attr_5000_devs_prefix': lambda : _do_simple_attr(5000, 10, 10, 'prefix'),
+    '1_attr_10_devs_infix': lambda : _do_simple_attr(10, 10, 1, 'infix'),
+    '1_attr_100_devs_infix': lambda : _do_simple_attr(100, 10, 1, 'infix'),
+    '1_attr_500_devs_infix': lambda : _do_simple_attr(500, 10, 1, 'infix'),
+    '1_attr_1000_devs_infix': lambda : _do_simple_attr(1000, 10, 1, 'infix'),
+    '1_attr_5000_devs_infix': lambda : _do_simple_attr(5000, 10, 1, 'infix'),
+    '5_attr_10_devs_infix': lambda : _do_simple_attr(10, 10, 5, 'infix'),
+    '5_attr_100_devs_infix': lambda : _do_simple_attr(100, 10, 5, 'infix'),
+    '5_attr_500_devs_infix': lambda : _do_simple_attr(500, 10, 5, 'infix'),
+    '5_attr_1000_devs_infix': lambda : _do_simple_attr(1000, 10, 5, 'infix'),
+    '5_attr_5000_devs_infix': lambda : _do_simple_attr(5000, 10, 5, 'infix'),
+    '10_attr_10_devs_infix': lambda : _do_simple_attr(10, 10, 10, 'infix'),
+    '10_attr_100_devs_infix': lambda : _do_simple_attr(100, 10, 10, 'infix'),
+    '10_attr_500_devs_infix': lambda : _do_simple_attr(500, 10, 10, 'infix'),
+    '10_attr_1000_devs_infix': lambda : _do_simple_attr(1000, 10, 10, 'infix'),
+    '10_attr_5000_devs_infix': lambda : _do_simple_attr(5000, 10, 10, 'infix'),
+    '1_attr_10_devs_mac': lambda : _do_simple_attr_mac(10, 10, 1),
+    '1_attr_100_devs_mac': lambda : _do_simple_attr_mac(100, 10, 1),
+    '1_attr_500_devs_mac': lambda : _do_simple_attr_mac(500, 10, 1),
+    '1_attr_1000_devs_mac': lambda : _do_simple_attr_mac(1000, 10, 1),
+    '1_attr_5000_devs_mac': lambda : _do_simple_attr_mac(5000, 10, 1),
+    '5_attr_10_devs_mac': lambda : _do_simple_attr_mac(10, 10, 5),
+    '5_attr_100_devs_mac': lambda : _do_simple_attr_mac(100, 10, 5),
+    '5_attr_500_devs_mac': lambda : _do_simple_attr_mac(500, 10, 5),
+    '5_attr_1000_devs_mac': lambda : _do_simple_attr_mac(1000, 10, 5),
+    '5_attr_5000_devs_mac': lambda : _do_simple_attr_mac(5000, 10, 5),
+    '10_attr_10_devs_mac': lambda : _do_simple_attr_mac(10, 10, 10),
+    '10_attr_100_devs_mac': lambda : _do_simple_attr_mac(100, 10, 10),
+    '10_attr_500_devs_mac': lambda : _do_simple_attr_mac(500, 10, 10),
+    '10_attr_1000_devs_mac': lambda : _do_simple_attr_mac(1000, 10, 10),
+    '10_attr_5000_devs_mac': lambda : _do_simple_attr_mac(5000, 10, 10),
+}
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='run an inventory search benchmark on a selected benchmark func.')
+    parser.add_argument('benchmark', metavar='benchmark', nargs='+', help='name of the benchmark function (starts with bench_)')
+    parser.add_argument('-c', dest='conns', default='100', help='number of concurrent connections, default=100')
+
+    args = parser.parse_args()
+
+    mongo = MongoClient()
+    mongo.drop_database('inventory')
+
+    print('running at {} conns'.format(args.conns))
+
+    bfun = benchmarks[args.benchmark[0]]
+    if bfun is not None:
+        run(bfun, c=args.conns)
+    else:
+        for f in benchmarks:
+            run(benchmarks[f], c=args.conns)

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -8,6 +8,7 @@ services:
             - "${TESTS_DIR}:/testing"
         depends_on:
             - mender-inventory
+      # command: -k test_regex
     mender-inventory:
             # built/tagged locally and only used for testing
             image: mendersoftware/inventory:prtest

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -1,0 +1,32 @@
+import random 
+import string
+
+# a bunch of generator funcs - random data according to patterns
+def rnum(min, max):
+    return random.uniform(min, max)
+
+def rnumarr(min, max, len):
+    return [random.uniform(min, max) for _ in range(len)]
+
+def rstr(n):
+    return ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(n))
+
+def rstrgen(n):
+    return lambda: rstr(n)
+
+def rstrarr(len, pattern, *gens):
+    ret = []
+    for _ in range(len):
+        generated = [g() for g in gens]
+        ret.append(pattern.format(*generated))
+    return ret
+
+# create an inventory-compatible device struct from an attribute dict
+def dev(attrs):
+    dev = {
+        'id': rstr(10),
+        'attributes':{}
+    }
+    for k in attrs:
+        dev['attributes'][k] = {'name': k, 'value': attrs[k], 'description': 'bogus filler description'}
+    return dev

--- a/tests/tests/test_regex.py
+++ b/tests/tests/test_regex.py
@@ -1,0 +1,185 @@
+import requests
+import pymongo
+
+from common import mongo, clean_db
+from generate import rstr, rstrarr, rnum, rnumarr, rstrgen, dev
+
+def test_regex_single_string_attr(clean_db):
+    '''
+        simplest possible test
+        couple devs with just a single field conforming to a pattern
+    '''
+    devs = []
+
+    # 9 devs matching A1
+    for _ in range(5):
+        devs.append(
+            dev({
+            'sn': '{}_A1_{}'.format(rstr(4), rstr(4)),
+        }))
+    for _ in range(3):
+        devs.append(
+            dev({
+            'sn': 'A1_{}'.format(rstr(10)),
+        }))
+    for _ in range(1):
+        devs.append(
+            dev({
+            'sn': '{}_A1'.format(rstr(10)),
+        }))
+
+    # 3 devs matching B1
+    for _ in range(3):
+        devs.append(
+            dev({
+            'sn': 'B1_{}'.format(rstr(10)),
+        }))
+
+    # 3 unrelated devs
+    for _ in range(3):
+        devs.append(
+            dev({
+            'sn': '{}'.format(rstr(10)),
+        }))
+
+    clean_db.inventory.devices.insert_many(devs)
+
+    # verify
+    r = api_search({'sn': '~A1'})
+    assert len(r.json()) == 9
+
+    r = api_search({'sn': 'regex:A1'})
+    assert len(r.json()) == 9
+
+    r = api_search({'sn': '~B1'})
+    assert len(r.json()) == 3
+
+def test_regex_many_string_attrs(clean_db):
+    '''
+        typical scenario
+        couple devs with >1 attributes, some conforming to a pattern
+    '''
+    devs = []
+
+    for _ in range(2):
+        devs.append(
+            dev({
+            'vendor-id': 'V1_{}'.format(rstr(4)),
+            'sn': 'sn-{}_A1_{}'.format(rstr(4), rstr(4)),
+        }))
+
+    for _ in range(3):
+        devs.append(
+            dev({
+            'vendor-id': 'V2_{}'.format(rstr(4)),
+            'sn': 'sn-{}_A2_{}'.format(rstr(4), rstr(4)),
+        }))
+
+    clean_db.inventory.devices.insert_many(devs)
+
+    # verify
+    r = api_search({'vendor-id': '~V1'})
+    assert len(r.json()) == 2
+
+    r = api_search({'vendor-id': '~V2'})
+    assert len(r.json()) == 3
+
+    r = api_search({'sn': '~A1'})
+    assert len(r.json()) == 2
+
+    r = api_search({'sn': '~A2'})
+    assert len(r.json()) == 3
+
+    r = api_search({'vendor-id': '~A2'})
+    assert len(r.json()) == 0
+
+def test_regex_strings_and_string_arrays(clean_db):
+    '''
+        some regexes match in simple attributes,
+        some in sub-array values
+    '''
+    devs = []
+
+    for _ in range(2):
+        devs.append(
+            dev({
+            'vendor-id': 'V1_{}'.format(rstr(4)),
+            'foos': rstrarr(3, 'V1_{}', rstrgen(3)),
+            'bars': ['common', 'B1', 'cc']
+        }))
+
+    for _ in range(2):
+        devs.append(
+            dev({
+            'vendor-id': 'V2_{}'.format(rstr(4)),
+            'foos': rstrarr(3, 'V2_{}', rstrgen(3)),
+            'bars': ['common', 'cc', 'B2']
+        }))
+
+    clean_db.inventory.devices.insert_many(devs)
+
+    # verify
+    r = api_search({'foos': '~V1'})
+    assert len(r.json()) == 2
+
+    r = api_search({'foos': '~V2'})
+    assert len(r.json()) == 2
+
+    r = api_search({'bars': '~B1'})
+    assert len(r.json()) == 2
+
+    r = api_search({'bars': '~B2'})
+    assert len(r.json()) == 2
+
+    r = api_search({'bars': '~common'})
+    assert len(r.json()) == 4
+
+def test_regex_complex(clean_db):
+    '''
+        devices with simple string attributes, 
+        some actual regexes, not just pre/post/infix
+    '''
+    devs = []
+
+    devs.append(
+        dev({
+            'mac': 'de:ad:be:ef:00:00',
+            'sn': 'vendor-00001-12345667',
+            'ip': 'invalid',
+    }))
+
+    devs.append(
+        dev({
+            'mac': 'de:ad:be:ef:00:01',
+            'sn': 'vendor-00001-12',
+            'ip': '192.0.0.1',
+    }))
+
+    devs.append(
+        dev({
+            'mac': 'de:ad:be:ef:00:02',
+            'sn': 'vendor-00001-12aaaa',
+            'ip': '192.0.0.2',
+    }))
+
+    devs.append(
+        dev({
+            'mac': 'not really a mac',
+            'sn': 'vendor-00001-12aaaa',
+            'ip': '192.0.0.3',
+    }))
+
+    clean_db.inventory.devices.insert_many(devs)
+
+    # verify
+    r = api_search({'mac': '~^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$'})
+    assert len(r.json()) == 3
+
+    r = api_search({'ip': '~^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'})
+    assert len(r.json()) == 3
+
+    r = api_search({'mac': 'de:ad:be:ef:00:01'})
+    assert len(r.json()) == 1
+
+def api_search(opts={}):
+    return requests.get("http://mender-inventory:8080/api/0.1.0/devices", opts)


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-1914

this is a POC preceding the breakdown of this epic.

Aims to assess the naive regex search implementation:
- semantically - can it be done, is the api usable
- performance-wise - isn't the performance catastrophic enough to dump the idea

IMO on both fronts we're ok.
The `$regex/~` operator is prototyped and tested with some acceptance tests and seems to work correctly.

A microbenchmark was created to check at least the basics of performance - see the markdown doc.