### PR TITLE
GET /devices v2

### DIFF
--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -496,8 +496,10 @@ func parseDeviceAttributes(r *rest.Request) (model.DeviceAttributes, error) {
 		return nil, errors.Wrap(err, "failed to decode request body")
 	}
 
-	for _, a := range attrs {
+	for i := range attrs {
+		a := attrs[i]
 		a.Scope = model.AttrScopeInventory
+		attrs[i] = a
 		if err = a.Validate(); err != nil {
 			return nil, err
 		}

--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -218,13 +218,13 @@ func (i *inventoryHandlers) GetDevicesV1Handler(w rest.ResponseWriter, r *rest.R
 		return
 	}
 
-	sort, err := parseSortParam(r)
+	sort, err := parseSortParamV1(r)
 	if err != nil {
 		u.RestErrWithLog(w, r, l, err, http.StatusBadRequest)
 		return
 	}
 
-	filters, err := parseFilterParams(r)
+	filters, err := parseFilterParamsV1(r)
 	if err != nil {
 		u.RestErrWithLog(w, r, l, err, http.StatusBadRequest)
 		return

--- a/api/http/api_inventory_test.go
+++ b/api/http/api_inventory_test.go
@@ -153,7 +153,7 @@ func floatPtr(f float64) *float64 {
 	ret := f
 	return &ret
 }
-func TestApiParseFilterParams(t *testing.T) {
+func TestApiParseFilterParamsV1(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
@@ -166,7 +166,7 @@ func TestApiParseFilterParams(t *testing.T) {
 			inReq: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=A0001", nil),
 			filters: []store.Filter{
 				store.Filter{
-					AttrName: "attr_name1",
+					AttrName: "inventory-attr_name1",
 					Value:    "A0001",
 					Operator: store.Eq,
 				},
@@ -176,7 +176,7 @@ func TestApiParseFilterParams(t *testing.T) {
 			inReq: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=qe:123:123:123", nil),
 			filters: []store.Filter{
 				store.Filter{
-					AttrName: "attr_name1",
+					AttrName: "inventory-attr_name1",
 					Value:    "qe:123:123:123",
 					Operator: store.Eq,
 				},
@@ -186,7 +186,7 @@ func TestApiParseFilterParams(t *testing.T) {
 			inReq: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=3.14", nil),
 			filters: []store.Filter{
 				store.Filter{
-					AttrName:   "attr_name1",
+					AttrName:   "inventory-attr_name1",
 					Value:      "3.14",
 					ValueFloat: floatPtr(3.14),
 					Operator:   store.Eq,
@@ -197,7 +197,7 @@ func TestApiParseFilterParams(t *testing.T) {
 			inReq: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=eq:A0001", nil),
 			filters: []store.Filter{
 				store.Filter{
-					AttrName: "attr_name1",
+					AttrName: "inventory-attr_name1",
 					Value:    "A0001",
 					Operator: store.Eq,
 				},
@@ -207,7 +207,7 @@ func TestApiParseFilterParams(t *testing.T) {
 			inReq: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/0.1.0/devices?page=1&per_page=5&attr_name1=eq:qe:123:123:123", nil),
 			filters: []store.Filter{
 				store.Filter{
-					AttrName: "attr_name1",
+					AttrName: "inventory-attr_name1",
 					Value:    "qe:123:123:123",
 					Operator: store.Eq,
 				},
@@ -218,7 +218,7 @@ func TestApiParseFilterParams(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(fmt.Sprintf("tc %s", name), func(t *testing.T) {
 			req := rest.Request{Request: testCase.inReq}
-			filters, err := parseFilterParams(&req)
+			filters, err := parseFilterParamsV1(&req)
 			if testCase.err != nil {
 				assert.Error(t, testCase.err, err.Error())
 			} else {
@@ -232,7 +232,7 @@ func TestApiParseFilterParams(t *testing.T) {
 	}
 }
 
-func TestApiInventoryGetDevices(t *testing.T) {
+func TestApiInventoryGetDevicesV1(t *testing.T) {
 	t.Parallel()
 	rest.ErrorFieldName = "error"
 

--- a/api/http/api_inventory_test.go
+++ b/api/http/api_inventory_test.go
@@ -394,6 +394,417 @@ func TestApiParseSortParam(t *testing.T) {
 	}
 }
 
+func TestApiInventoryGetDevices(t *testing.T) {
+	t.Parallel()
+	rest.ErrorFieldName = "error"
+
+	inDevs := []model.Device{
+		{
+			ID: model.DeviceID("1"),
+			Attributes: model.DeviceAttributes{
+				"foo": model.DeviceAttribute{
+					Name:  "foo",
+					Value: []interface{}{"foo", "bar"},
+					Scope: "system",
+				},
+			},
+		},
+		{
+			ID: model.DeviceID("2"),
+			Attributes: model.DeviceAttributes{
+				"foo": model.DeviceAttribute{
+					Name:  "foo",
+					Value: "bar",
+					Scope: "inventory",
+				},
+			},
+		},
+		{
+			ID: model.DeviceID("3"),
+			Attributes: model.DeviceAttributes{
+				"bar": model.DeviceAttribute{
+					Name:  "bar",
+					Value: "bar",
+					Scope: "identity",
+				},
+				"baz": model.DeviceAttribute{
+					Name:  "baz",
+					Value: "baz",
+					Scope: "identity",
+				},
+			},
+		},
+		{
+			ID: model.DeviceID("4"),
+			Attributes: model.DeviceAttributes{
+				"foo-id": model.DeviceAttribute{
+					Name:  "foo",
+					Value: []interface{}{"foo", "bar"},
+					Scope: "identity",
+				},
+				"bar-id": model.DeviceAttribute{
+					Name:  "bar",
+					Value: []interface{}{1.2, 3.4},
+					Scope: "identity",
+				},
+				"foo-sys": model.DeviceAttribute{
+					Name:  "foo",
+					Value: "val",
+					Scope: "system",
+				},
+				"bar-sys": model.DeviceAttribute{
+					Name:  "bar",
+					Value: 123,
+					Scope: "system",
+				},
+				"baz-inv": model.DeviceAttribute{
+					Name:  "baz",
+					Value: []interface{}{"baz"},
+					Scope: "inventory",
+				},
+			},
+		},
+		{
+			ID: model.DeviceID("5"),
+			Attributes: model.DeviceAttributes{
+				"foo-sys": model.DeviceAttribute{
+					Name:  "foo",
+					Value: 123,
+					Scope: "system",
+				},
+			},
+		},
+	}
+
+	outDevs := []DeviceDto{
+		{
+			ID: "1",
+			Attributes: map[string][]model.DeviceAttribute{
+				"system": []model.DeviceAttribute{
+					{
+						Name:  "foo",
+						Value: []interface{}{"foo", "bar"},
+						Scope: "system",
+					},
+				},
+				"identity":  []model.DeviceAttribute{},
+				"custom":    []model.DeviceAttribute{},
+				"inventory": []model.DeviceAttribute{},
+			},
+		},
+		{
+			ID: "2",
+			Attributes: map[string][]model.DeviceAttribute{
+				"inventory": []model.DeviceAttribute{
+					{
+						Name:  "foo",
+						Value: "bar",
+						Scope: "inventory",
+					},
+				},
+				"identity": []model.DeviceAttribute{},
+				"custom":   []model.DeviceAttribute{},
+				"system":   []model.DeviceAttribute{},
+			},
+		},
+		{
+			ID: "3",
+			Attributes: map[string][]model.DeviceAttribute{
+				"identity": []model.DeviceAttribute{
+					{
+						Name:  "bar",
+						Value: "bar",
+						Scope: "identity",
+					},
+					{
+						Name:  "baz",
+						Value: "baz",
+						Scope: "identity",
+					},
+				},
+				"system":    []model.DeviceAttribute{},
+				"inventory": []model.DeviceAttribute{},
+				"custom":    []model.DeviceAttribute{},
+			},
+		},
+		{
+			ID: "4",
+			Attributes: map[string][]model.DeviceAttribute{
+				"identity": []model.DeviceAttribute{
+					{
+						Name:  "bar",
+						Value: []interface{}{1.2, 3.4},
+						Scope: "identity",
+					},
+					{
+						Name:  "foo",
+						Value: []interface{}{"foo", "bar"},
+						Scope: "identity",
+					},
+				},
+				"system": []model.DeviceAttribute{
+					{
+						Name:  "bar",
+						Value: 123,
+						Scope: "system",
+					},
+					{
+						Name:  "foo",
+						Value: "val",
+						Scope: "system",
+					},
+				},
+				"inventory": []model.DeviceAttribute{
+					{
+						Name:  "baz",
+						Value: []interface{}{"baz"},
+						Scope: "inventory",
+					},
+				},
+				"custom": []model.DeviceAttribute{},
+			},
+		},
+		{
+			ID: "5",
+			Attributes: map[string][]model.DeviceAttribute{
+				"system": {
+					model.DeviceAttribute{
+						Name:  "foo",
+						Value: 123,
+						Scope: "system",
+					},
+				},
+				"inventory": []model.DeviceAttribute{},
+				"identity":  []model.DeviceAttribute{},
+				"custom":    []model.DeviceAttribute{},
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		devs  []model.Device
+		total int
+		err   error
+
+		req  *http.Request
+		resp utils.JSONResponseParams
+	}{
+		"get all devices in group": {
+			devs:  inDevs,
+			total: 18,
+			req:   test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=4&per_page=5&group=foo", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     200,
+				OutputBodyObject: outDevs,
+				OutputHeaders: map[string][]string{
+					"Link": {
+						fmt.Sprintf(utils.LinkTmpl, "devices", "group=foo&page=3&per_page=5", "prev"),
+						fmt.Sprintf(utils.LinkTmpl, "devices", "group=foo&page=1&per_page=5", "first"),
+					},
+					"X-Total-Count": {"18"},
+				},
+			},
+		},
+		"valid pagination, no next page": {
+			devs:  inDevs,
+			total: 20,
+			req:   test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=4&per_page=5", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     200,
+				OutputBodyObject: outDevs,
+				OutputHeaders: map[string][]string{
+					"Link": {
+						fmt.Sprintf(utils.LinkTmpl, "devices", "page=3&per_page=5", "prev"),
+						fmt.Sprintf(utils.LinkTmpl, "devices", "page=1&per_page=5", "first"),
+					},
+					"X-Total-Count": {"20"},
+				},
+			},
+		},
+		"valid pagination, with next page": {
+			devs:  inDevs,
+			total: 21,
+			req:   test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=4&per_page=5", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     200,
+				OutputBodyObject: outDevs,
+				OutputHeaders: map[string][]string{
+					"Link": {
+						fmt.Sprintf(utils.LinkTmpl, "devices", "page=3&per_page=5", "prev"),
+						fmt.Sprintf(utils.LinkTmpl, "devices", "page=1&per_page=5", "first"),
+					},
+					"X-Total-Count": {"21"},
+				},
+			},
+		},
+		"invalid pagination - page format": {
+			devs:  inDevs,
+			total: 5,
+
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=foo&per_page=5", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     400,
+				OutputBodyObject: RestError(utils.MsgQueryParmInvalid("page")),
+				OutputHeaders:    nil,
+			},
+		},
+		"invalid pagination - per_page format": {
+			devs:  inDevs,
+			total: 5,
+
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=1&per_page=foo", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     400,
+				OutputBodyObject: RestError(utils.MsgQueryParmInvalid("per_page")),
+				OutputHeaders:    nil,
+			},
+		},
+		"invalid pagination - bounds": {
+			devs:  inDevs,
+			total: 5,
+
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=0&per_page=5", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     400,
+				OutputBodyObject: RestError(utils.MsgQueryParmLimit("page")),
+				OutputHeaders:    nil,
+			},
+		},
+		"valid attribute filter": {
+			devs:  inDevs[2:],
+			total: 3,
+
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=1&per_page=5&identity:attr_name1=qe:123:123:123", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     200,
+				OutputBodyObject: outDevs[2:],
+				OutputHeaders: map[string][]string{
+					"Link": {
+						fmt.Sprintf(utils.LinkTmpl, "devices", "identity%3Aattr_name1=qe%3A123%3A123%3A123&page=1&per_page=5", "first"),
+					},
+					"X-Total-Count": {"3"},
+				},
+			},
+		},
+		"invalid attribute filter: no scope": {
+			devs:  inDevs,
+			total: 5,
+
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=1&per_page=5&attr_name1=qe:123:123:123", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     400,
+				OutputBodyObject: RestError("invalid filter 'attr_name1': must include scope and name (e.g. 'identity:mac')"),
+				OutputHeaders:    nil,
+			},
+		},
+		"invalid attribute filter: forbidden scope": {
+			devs:  inDevs,
+			total: 5,
+
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=1&per_page=5&system:attr_name1=qe:123:123:123", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     400,
+				OutputBodyObject: RestError("supported attribute scopes: [ identity ]"),
+				OutputHeaders:    nil,
+			},
+		},
+		"valid sort order value": {
+			devs:  inDevs[1:],
+			total: 4,
+
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?sort=identity:attr_name1:asc&page=1&per_page=5", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     200,
+				OutputBodyObject: outDevs[1:],
+				OutputHeaders: map[string][]string{
+					"Link": {
+						fmt.Sprintf(utils.LinkTmpl, "devices", "page=1&per_page=5&sort=identity%3Aattr_name1%3Aasc", "first"),
+					},
+					"X-Total-Count": {"4"},
+				},
+			},
+		},
+		"invalid sort order: value": {
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=1&per_page=5&sort=identity:attr_name1:gte", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     400,
+				OutputBodyObject: RestError("invalid sort order"),
+				OutputHeaders:    nil,
+			},
+		},
+		"invalid sort order: no scope": {
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=1&per_page=5&sort=attr_name1", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     400,
+				OutputBodyObject: RestError("invalid sort 'attr_name1': must include at minimum scope and name (e.g. 'identity:mac')"),
+				OutputHeaders:    nil,
+			},
+		},
+		"invalid sort order: forbidden scope": {
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=1&per_page=5&sort=attr_name1", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     400,
+				OutputBodyObject: RestError("invalid sort 'attr_name1': must include at minimum scope and name (e.g. 'identity:mac')"),
+				OutputHeaders:    nil,
+			},
+		},
+		"valid has_group": {
+			devs:  inDevs,
+			total: 5,
+
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?has_group=true&page=1&per_page=5", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     200,
+				OutputBodyObject: outDevs,
+				OutputHeaders: map[string][]string{
+					"Link": {
+						fmt.Sprintf(utils.LinkTmpl, "devices", "has_group=true&page=1&per_page=5", "first"),
+					},
+					"X-Total-Count": {"5"},
+				},
+			},
+		},
+		"invalid has_group": {
+			devs:  inDevs,
+			total: 5,
+
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=1&per_page=5&has_group=asd", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     400,
+				OutputBodyObject: RestError(utils.MsgQueryParmInvalid("has_group")),
+				OutputHeaders:    nil,
+			},
+		},
+		"inv.ListDevices error": {
+			err: errors.New("inventory error"),
+			req: test.MakeSimpleRequest("GET", "http://1.2.3.4/api/management/v2/inventory/devices?page=4&per_page=5", nil),
+			resp: utils.JSONResponseParams{
+				OutputStatus:     500,
+				OutputBodyObject: RestError("internal error"),
+				OutputHeaders:    nil,
+			},
+		},
+	}
+
+	for name := range testCases {
+		n := name
+		t.Run(fmt.Sprintf("tc %s", n), func(t *testing.T) {
+			tc := testCases[n]
+			inv := minventory.InventoryApp{}
+			ctx := contextMatcher()
+
+			inv.On("ListDevices",
+				ctx,
+				mock.AnythingOfType("store.ListQuery"),
+			).Return(tc.devs, tc.total, tc.err)
+
+			apih := makeMockApiHandler(t, &inv)
+
+			runTestRequest(t, apih, tc.req, tc.resp)
+		})
+	}
+}
+
 func TestApiInventoryGetDevicesV1(t *testing.T) {
 	t.Parallel()
 	rest.ErrorFieldName = "error"

--- a/api/http/dto.go
+++ b/api/http/dto.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package http
+
+import (
+	"sort"
+	"time"
+
+	"github.com/mendersoftware/inventory/model"
+)
+
+type DeviceDto struct {
+	ID         string                             `json:"id"`
+	Attributes map[string][]model.DeviceAttribute `json:"attributes"`
+	UpdatedTs  time.Time                          `json:"updated_ts"`
+}
+
+func NewDeviceDto(d *model.Device) *DeviceDto {
+	dto := &DeviceDto{
+		ID:         string(d.ID),
+		UpdatedTs:  d.UpdatedTs,
+		Attributes: map[string][]model.DeviceAttribute{},
+	}
+
+	for _, s := range model.AllScopes {
+		dto.Attributes[s] = []model.DeviceAttribute{}
+	}
+
+	for _, a := range d.Attributes {
+		dto.Attributes[a.Scope] = append(dto.Attributes[a.Scope], a)
+	}
+
+	for _, attrs := range dto.Attributes {
+		sort.Slice(attrs, func(i, j int) bool {
+			return attrs[j].Name > attrs[i].Name
+		})
+	}
+
+	return dto
+}

--- a/api/http/dto_test.go
+++ b/api/http/dto_test.go
@@ -1,0 +1,190 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package http
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mendersoftware/inventory/model"
+)
+
+var now = time.Now()
+
+func TestNewDeviceDto(t *testing.T) {
+	t.Parallel()
+
+	tcs := []struct {
+		in  *model.Device
+		out *DeviceDto
+	}{
+		{
+			in: &model.Device{
+				ID:        model.DeviceID("123"),
+				UpdatedTs: now,
+			},
+			out: &DeviceDto{
+				ID: "123",
+				Attributes: map[string][]model.DeviceAttribute{
+					"system":    []model.DeviceAttribute{},
+					"inventory": []model.DeviceAttribute{},
+					"identity":  []model.DeviceAttribute{},
+					"custom":    []model.DeviceAttribute{},
+				},
+				UpdatedTs: now,
+			},
+		},
+		{
+			in: &model.Device{
+				ID: model.DeviceID("123"),
+				Attributes: model.DeviceAttributes{
+					"foo": model.DeviceAttribute{
+						Name:  "foo",
+						Value: "bar",
+						Scope: "inventory",
+					},
+				},
+				UpdatedTs: now,
+			},
+			out: &DeviceDto{
+				ID: "123",
+				Attributes: map[string][]model.DeviceAttribute{
+					"inventory": []model.DeviceAttribute{
+						{
+							Name:  "foo",
+							Value: "bar",
+							Scope: "inventory",
+						},
+					},
+					"system":   []model.DeviceAttribute{},
+					"identity": []model.DeviceAttribute{},
+					"custom":   []model.DeviceAttribute{},
+				},
+				UpdatedTs: now,
+			},
+		},
+		{
+			in: &model.Device{
+				ID: model.DeviceID("123"),
+				Attributes: model.DeviceAttributes{
+					"foo": model.DeviceAttribute{
+						Name:  "foo",
+						Value: []interface{}{"foo", "bar"},
+						Scope: "system",
+					},
+				},
+				UpdatedTs: now,
+			},
+			out: &DeviceDto{
+				ID: "123",
+				Attributes: map[string][]model.DeviceAttribute{
+					"system": []model.DeviceAttribute{
+						{
+							Name:  "foo",
+							Value: []interface{}{"foo", "bar"},
+							Scope: "system",
+						},
+					},
+					"inventory": []model.DeviceAttribute{},
+					"identity":  []model.DeviceAttribute{},
+					"custom":    []model.DeviceAttribute{},
+				},
+				UpdatedTs: now,
+			},
+		},
+		{
+			in: &model.Device{
+				ID: model.DeviceID("123"),
+				Attributes: model.DeviceAttributes{
+					"foo-id": model.DeviceAttribute{
+						Name:  "foo",
+						Value: []interface{}{"foo", "bar"},
+						Scope: "identity",
+					},
+					"bar-id": model.DeviceAttribute{
+						Name:  "bar",
+						Value: []interface{}{1.2, 3.4},
+						Scope: "identity",
+					},
+					"foo-sys": model.DeviceAttribute{
+						Name:  "foo",
+						Value: "val",
+						Scope: "system",
+					},
+					"bar-sys": model.DeviceAttribute{
+						Name:  "bar",
+						Value: 123,
+						Scope: "system",
+					},
+					"baz-inv": model.DeviceAttribute{
+						Name:  "baz",
+						Value: []interface{}{"baz"},
+						Scope: "inventory",
+					},
+				},
+				UpdatedTs: now,
+			},
+			out: &DeviceDto{
+				ID: "123",
+				Attributes: map[string][]model.DeviceAttribute{
+					"identity": []model.DeviceAttribute{
+						{
+							Name:  "bar",
+							Value: []interface{}{1.2, 3.4},
+							Scope: "identity",
+						},
+						{
+							Name:  "foo",
+							Value: []interface{}{"foo", "bar"},
+							Scope: "identity",
+						},
+					},
+					"inventory": []model.DeviceAttribute{
+						{
+							Name:  "baz",
+							Value: []interface{}{"baz"},
+							Scope: "inventory",
+						},
+					},
+					"system": []model.DeviceAttribute{
+						model.DeviceAttribute{
+							Name:  "bar",
+							Value: 123,
+							Scope: "system",
+						},
+						model.DeviceAttribute{
+							Name:  "foo",
+							Value: "val",
+							Scope: "system",
+						},
+					},
+					"custom": []model.DeviceAttribute{},
+				},
+				UpdatedTs: now,
+			},
+		},
+	}
+
+	for i := range tcs {
+		tc := tcs[i]
+		t.Run(fmt.Sprintf("tc %d", i), func(t *testing.T) {
+
+			dto := NewDeviceDto(tc.in)
+			assert.Equal(t, tc.out, dto)
+		})
+	}
+}

--- a/docs/management_api_v2.yml
+++ b/docs/management_api_v2.yml
@@ -1,0 +1,276 @@
+swagger: '2.0'
+info:
+  version: '1'
+  title: Device inventory
+  description: |
+    An API for device attribute management and device grouping. Intended for use by the web GUI.
+
+    Devices can upload vendor-specific attributes (software/hardware info, health checks, metrics, etc.) of various data types to the backend.
+
+    This API enables the user to:
+    * list devices with their attributes
+    * search devices by attribute value
+    * use the results to create and manage device groups for the purpose of deployment scheduling
+
+basePath: '/api/management/v2/inventory'
+host: 'docker.mender.io'
+schemes:
+  - https
+
+paths:
+  /devices:
+    get:
+      summary: List devices
+      description:  |
+        Returns a paged collection of devices and their attributes.
+        Accepts optional search and sort parameters.
+
+        **Searching**
+        To search devices by attribute values, append attribute name/value pairs
+        to the query string.
+        Each attribute name must be prepended by its scope, e.g.:
+
+        ```
+        GET /devices?identity:attr_name_1=foo&
+                     identity:attr_name_2=100&
+                     ...
+        ```
+        Currently the only supported scope for searching is the 'identity' scope.
+
+        **Sorting**
+        To sort the device list by an attribute value, use the 'sort' parameter with an attribute name.
+        Each attribute name must be accompanied by its scope, e.g.:
+
+        ```
+        GET /devices?sort=identity:attr_name_1
+        ```
+
+        Optionally you can provide the sort direction - 'desc' (default) or 'asc', e.g.:
+
+        ```
+        GET /devices?sort=identity:attr_name_1:asc
+        ```
+
+        Sort can be combined with search.
+
+        Currently the only supported scope for sorting is the 'identity' scope.
+
+      parameters:
+        - name: Authorization
+          in: header
+          required: true
+          type: string
+          format: Bearer [token]
+          description: Contains the JWT token issued by the User Administration and Authentication Service.
+        - name: page
+          in: query
+          description: Starting page.
+          required: false
+          type: number
+          format: integer
+          default: 1
+        - name: per_page
+          in: query
+          description: Number of results per page.
+          required: false
+          type: number
+          format: integer
+          default: 10
+        - name: sort
+          in: query
+          description: |
+            Supports sorting the device list by attribute values.
+
+            The parameter is formatted as attribute scope/name and optional sort direction, e.g.:
+
+            '?sort=identity:attr1:asc'
+
+            will sort by 'attr1' (in scope 'identity'), in ascending order. 'desc' is the default value.
+
+          required: false
+          type: string
+        - name: has_group
+          in: query
+          description: If present, limits the results only to devices assigned/not assigned to a group.
+          required: false
+          type: boolean
+        - name: group
+          in: query
+          description: If present, limits the results only to devices belonging to the given group.
+          required: false
+          type: string
+
+      responses:
+        200:
+          description: Successful response.
+          headers:
+            Link:
+              type: string
+              description: |
+                Standard header, used for page navigation.
+
+                Supported relation types are 'first', 'next' and 'prev'.
+            X-Total-Count:
+              type: string
+              description: Custom header indicating the total number of devices for the given query parameters
+          schema:
+            title: ListOfDevices
+            type: array
+            items:
+              $ref: '#/definitions/DeviceWithGroupedAttributes'
+          examples:
+            application/json:
+              - id: "291ae0e5956c69c2267489213df4459d19ed48a806603def19d417d004a4b67e"
+                attributes:
+                  identity:
+                    - name: "ip_addr"
+                      value: "1.2.3.4"
+                      description: "IP address"
+                      scope: "identity"
+                    - name: "mac_addr"
+                      value: "00.01:02:03:04:05"
+                      description: "MAC address"
+                      scope: "identity"
+                  inventory:
+                    - name: "ports"
+                      value:
+                        - "8080"
+                        - "8081"
+                      description: "Open ports"
+                      scope: "inventory"
+                  system: []
+                  custom: []
+                updated_ts: "2016-10-03T16:58:51.639Z"
+              - id: "76f40e5956c699e327489213df4459d1923e1a806603def19d417d004a4a3ef"
+                attributes:
+                  identity: 
+                    - name: "mac"
+                      value: "00:01:02:03:04:05"
+                      description: "MAC address"
+                      scope: "identity"
+                  inventory: []
+                  system: []
+                  custom: []
+                updated_ts: "2016-10-04T18:24:21.432Z"
+        400:
+          description: Missing or malformed request parameters. See error for details.
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Internal error.
+          schema:
+            $ref: '#/definitions/Error'
+
+definitions:
+  DeviceWithGroupedAttributes:
+    description: | 
+      Device object with attributes grouped by scopes.
+    type: object
+    properties:
+      id:
+        type: string
+        description: Mender-assigned unique ID.
+      updated_ts:
+        type: string
+        description: Timestamp of the most recent attribute update.
+      attributes:
+        $ref: '#/definitions/ScopedAttributes'
+        description: Attribute descriptors grouped by scope.
+
+  ScopedAttributes:
+    description: | 
+      Attributes grouped by scope.
+      Scope is one of:
+        - identity
+        - inventory
+        - custom
+        - system
+    type: object
+    properties:
+      identity:
+          type: array
+          items:
+            $ref: '#/definitions/Attribute'
+      inventory:
+          type: array
+          items:
+            $ref: '#/definitions/Attribute'
+      custom:
+          type: array
+          items:
+            $ref: '#/definitions/Attribute'
+      system:
+          type: array
+          items:
+            $ref: '#/definitions/Attribute'
+    example:
+      application/json:
+         identity:
+           - name: "ip_addr"
+             value: "1.2.3.4"
+             description: "IP address"
+             scope: "identity"
+           - name: "mac_addr"
+             value: "00.01:02:03:04:05"
+             description: "MAC address"
+             scope: "identity"
+         inventory:
+           - name: "ports"
+             value:
+               - "8080"
+               - "8081"
+             description: "Open ports"
+             scope: "inventory"
+         system: []
+         custom: []
+
+  Attribute:
+    description: Attribute descriptor.
+    type: object
+    properties:
+      name:
+        type: string
+        description: |
+            A human readable, unique attribute ID, e.g. 'device_type', 'ip_addr', 'cpu_load', etc.
+      description:
+        type: string
+        description: Attribute description.
+      value:
+        type: string
+        description: |
+            The current value of the attribute.
+
+            Attribute type is implicit, inferred from the JSON type.
+
+            Supported types: number, string, array of numbers, array of strings. Mixed arrays are not allowed.
+      scope:
+        type: string
+        enum:
+          - identity
+          - inventory
+          - custom
+          - system
+        description: |
+            The scope of the attribute.
+            Each attribute has its scope.
+            It prevents overwriting attributes provided by different actors in the system and having the same name.
+    example:
+      application/json:
+        name: "cpu_load"
+        description: "The current CPU load."
+        value: 42
+
+  Error:
+    description: Error descriptor.
+    type: object
+    properties:
+      error:
+        description: Description of the error.
+        type: string
+      request_id:
+        description: Request ID (same as in X-MEN-RequestID header).
+        type: string
+    example:
+      application/json:
+          error: "failed to decode device group data: JSON payload is empty"
+          request_id: "f7881e82-0492-49fb-b459-795654e7188a"

--- a/model/device.go
+++ b/model/device.go
@@ -25,7 +25,15 @@ const (
 	AttrScopeInventory = "inventory"
 	AttrScopeSystem    = "system"
 	AttrScopeIdentity  = "identity"
+	AttrScopeCustom    = "custom"
 )
+
+var AllScopes = []string{
+	AttrScopeInventory,
+	AttrScopeSystem,
+	AttrScopeIdentity,
+	AttrScopeCustom,
+}
 
 type DeviceID string
 

--- a/model/device.go
+++ b/model/device.go
@@ -24,6 +24,7 @@ import (
 const (
 	AttrScopeInventory = "inventory"
 	AttrScopeSystem    = "system"
+	AttrScopeIdentity  = "identity"
 )
 
 type DeviceID string

--- a/tests/tests/test_inventory_searching.py
+++ b/tests/tests/test_inventory_searching.py
@@ -25,11 +25,11 @@ class TestInventorySearching:
             internal_client.create_device(did, it)
 
         r = requests.get(management_client.client.swagger_spec.api_url + "/devices",
-                         params=({"inventory-users_logged_in": 100}),
+                         params=({"users_logged_in": 100}),
                          verify=False)
         assert len(r.json()) == 1
 
         r = requests.get(management_client.client.swagger_spec.api_url + "/devices",
-                         params=({"inventory-open_connections": 1231}),
+                         params=({"open_connections": 1231}),
                          verify=False)
         assert len(r.json()) == 1

--- a/tests/tests/test_inventory_sorting.py
+++ b/tests/tests/test_inventory_sorting.py
@@ -22,7 +22,7 @@ class TestInventorySorting:
             internal_client.create_device(did, it)
 
         t = []
-        r = management_client.getAllDevices(sort="inventory-number:asc")
+        r = management_client.getAllDevices(sort="number:asc")
         for deviceInventoryList in r:
             for i in deviceInventoryList.attributes:
                 if i.name == "number":
@@ -31,7 +31,7 @@ class TestInventorySorting:
         assert sorted(numbers) == t
 
         t = []
-        r, h = management_client.client.devices.get_devices(sort="inventory-number:desc",
+        r, h = management_client.client.devices.get_devices(sort="number:desc",
                                                             Authorization="foo").result()
         for deviceInventoryList in r:
             for i in deviceInventoryList.attributes:


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-2523

the first 2 commits are a bugfix of the recent v1 modification, at least i'm 99% sure it's what it should look like @kjaskiewiczz.

also, the last commit is a fix to the modified `PATCH v1/devices` (fixed scope assignments).

also, to discuss:

- I created `management_api_v2.yml`, with just the `GET v2/devices` endpoint - will later be moved to just `management_api.yml` (we can't do it just yet - v1 EPs were not rerouted yet to v2) - is that correct?
it seems like this to me, e.g. acceptance tests need functioning v1 still...

- we're introducing a separate Device resource (with grouped attributes) for GET v2. should we also migrate `GET v2/devices/:id` to this new representation? or leave it as is. we might need an extra followup task

there's an accompanying change in the gateway: 
https://github.com/mendersoftware/mender-api-gateway-docker/pull/104
