### PR TITLE
tests/common: mongo cleanup: don't cleanup 'config' db

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -28,7 +28,7 @@ def mongo():
 
 def mongo_cleanup(mongo):
     dbs = mongo.database_names()
-    dbs = [d for d in dbs if d not in ['local', 'admin']]
+    dbs = [d for d in dbs if d not in ['local', 'admin', 'config']]
     for d in dbs:
         mongo.drop_database(d)
 


### PR DESCRIPTION
reason:

pymongo.errors.OperationFailure: Direct writes against
config.transactions cannot be performed using a transaction or on a
session.

introduced in 3.6 apparently - sessions are used by default, and
'config' is untouchable on a session.

https://jira.mongodb.org/browse/SERVER-35244