### PR TITLE
internal endpoint to set the attributes in scope for a device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _testmain.go
 .vscode/.browse.VC.db-wal
 .vscode/launch.json
 .vscode/.browse.VC.db-shm
+.idea

--- a/model/device.go
+++ b/model/device.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	AttrScopeInventory = "inventory"
+	AttrScopeIdentity  = "identity"
 )
 
 type DeviceID string


### PR DESCRIPTION
Internal endpoint to set a status of given devices
--

* **deviceauth** calls _update_device_status_ [[1](https://github.com/mendersoftware/workflows/pull/40)] workflow to propagate information on device status to inventory.
* **inventory** exposes internal API to set status for a list of devices [[2](https://github.com/mendersoftware/inventory-enterprise/pull/24)].
* _/filters/search_ can be use by UI to get list of devices as a single place of information.
* a new scope `identity` [4](https://github.com/mendersoftware/integration/pull/881)

related PRs:
 * [1] https://github.com/mendersoftware/workflows/pull/40
 * [2] https://github.com/mendersoftware/inventory-enterprise/pull/24
 * [3] https://github.com/mendersoftware/deviceauth/pull/324
 * [4] https://github.com/mendersoftware/integration/pull/881

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>