### PR TITLE
FIX: Replace fieldnames containing '.' and '$'

### DIFF
--- a/model/device.go
+++ b/model/device.go
@@ -16,6 +16,7 @@ package model
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/go-ozzo/ozzo-validation"
@@ -239,7 +240,9 @@ func (d *DeviceAttributes) UnmarshalBSONValue(t bsontype.Type, b []byte) error {
 // "<scope>-<name>".
 func (d DeviceAttributes) MarshalBSONValue() (bsontype.Type, []byte, error) {
 	attrs := make(bson.D, len(d))
+	replacer := strings.NewReplacer(".", "_", "$", "_S_")
 	for i := range d {
+		d[i].Name = replacer.Replace(d[i].Name)
 		attrs[i].Key = d[i].Scope + "-" + d[i].Name
 		attrs[i].Value = &d[i]
 	}

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -353,6 +353,7 @@ func makeAttrField(attrName, attrScope string, subFields ...string) string {
 func makeAttrUpsert(attrs model.DeviceAttributes) (bson.M, error) {
 	var fieldName string
 	upsert := make(bson.M)
+	replacer := strings.NewReplacer(".", "_", "$", "_S_")
 
 	for i := range attrs {
 		if attrs[i].Name == "" {
@@ -362,6 +363,7 @@ func makeAttrUpsert(attrs model.DeviceAttributes) (bson.M, error) {
 			// Default to inventory scope
 			attrs[i].Scope = model.AttrScopeInventory
 		}
+		attrs[i].Name = replacer.Replace(attrs[i].Name)
 
 		fieldName = makeAttrField(
 			attrs[i].Name,


### PR DESCRIPTION
As fieldnames containing dots gets transformed to embedded documents, we
must disallow such fields from making it to the DB. This PR replaces
such field names using the following replacements:
 - `'.'` -> `'_'`
 - `'$'` -> `'_S_'`