### PR TITLE
Delete device upon receiving _decommission_ status update.

### DIFF
--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -389,7 +389,7 @@ func (i *inventoryHandlers) PatchDeviceAttributesInternalHandler(w rest.Response
 	l := log.FromContext(ctx)
 
 	deviceId := r.PathParam("did")
-	if len(deviceId)<1 {
+	if len(deviceId) < 1 {
 		u.RestErrWithLog(w, r, l, errors.New("device id cannot be empty"), http.StatusBadRequest)
 		return
 	}
@@ -802,8 +802,13 @@ func (i *inventoryHandlers) InternalDevicesStatusHandler(w rest.ResponseWriter, 
 				Scope:       model.AttrScopeIdentity,
 			},
 		}
-		//upsert the attributes
-		err = i.inventory.UpsertAttributes(ctx, model.DeviceID(id), attrs)
+
+		if status == "decommissioned" {
+			err = i.inventory.DeleteDevice(ctx, model.DeviceID(id))
+		} else {
+			//upsert the attributes
+			err = i.inventory.UpsertAttributes(ctx, model.DeviceID(id), attrs)
+		}
 		if err != nil {
 			u.RestErrWithLogInternal(w, r, l, err)
 			return


### PR DESCRIPTION
Deviceauth synces all statuses to inventory service.
In case of device being dismissed from the preauthorized devices list
(user did not accept the device) there is no status to sync, so:

 * update device status with _decommissioned_ status is called
 * inventory service deletes device when it receives the update

see: deviceauth/28926e747f9c9ac06dafe3eca679b796f5e1e5b6
https://github.com/mendersoftware/deviceauth/pull/355

Changelog: none
Signed-off-by: Peter Grzybowski <peter@northern.tech>