### PR TITLE
API spec fixes: schema and hostname

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -8,7 +8,7 @@ info:
     Devices can upload vendor-specific attributes (software/hardware info, health checks, metrics, etc.) of various data types to the backend.
 
 basePath: '/api/devices/v1/inventory'
-host: 'docker.mender.io'
+host: 'hosted.mender.io'
 schemes:
   - https
 

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -13,7 +13,7 @@ info:
     * use the results to create and manage device groups for the purpose of deployment scheduling
 
 basePath: '/api/management/v1/inventory'
-host: 'docker.mender.io'
+host: 'hosted.mender.io'
 schemes:
   - https
 

--- a/docs/management_api_v2.yml
+++ b/docs/management_api_v2.yml
@@ -13,7 +13,7 @@ info:
     * use the results to create and manage device groups for deployment scheduling
 
 basePath: '/api/management/v2/inventory'
-host: 'docker.mender.io'
+host: 'hosted.mender.io'
 schemes:
   - https
 


### PR DESCRIPTION
* [API spec] Consistently use host hosted.mender.io across all repos