### PR TITLE
MEN-3906: Add status query parameter to GET /groups

### DIFF
--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -642,11 +642,23 @@ func parseAttributes(r *rest.Request) (model.DeviceAttributes, error) {
 }
 
 func (i *inventoryHandlers) GetGroupsHandler(w rest.ResponseWriter, r *rest.Request) {
+	var fltr []model.FilterPredicate
 	ctx := r.Context()
 
 	l := log.FromContext(ctx)
 
-	groups, err := i.inventory.ListGroups(ctx)
+	query := r.URL.Query()
+	status := query.Get("status")
+	if status != "" {
+		fltr = []model.FilterPredicate{{
+			Attribute: "status",
+			Scope:     "identity",
+			Type:      "$eq",
+			Value:     status,
+		}}
+	}
+
+	groups, err := i.inventory.ListGroups(ctx, fltr)
 	if err != nil {
 		u.RestErrWithLogInternal(w, r, l, err)
 		return

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -304,7 +304,14 @@ paths:
         - Management API
       security:
         - ManagementJWT: []
+
       summary: List all groups existing device groups
+      parameters:
+        - name: status
+          in: query
+          description: Show groups for devices with the given auth set status.
+          required: false
+          type: string
       responses:
         200:
           description: Successful response.

--- a/inv/inventory.go
+++ b/inv/inventory.go
@@ -49,7 +49,7 @@ type InventoryApp interface {
 		ids []model.DeviceID,
 		group model.GroupName,
 	) (*model.UpdateResult, error)
-	ListGroups(ctx context.Context) ([]model.GroupName, error)
+	ListGroups(ctx context.Context, filters []model.FilterPredicate) ([]model.GroupName, error)
 	ListDevicesByGroup(ctx context.Context, group model.GroupName, skip int, limit int) ([]model.DeviceID, int, error)
 	GetDeviceGroup(ctx context.Context, id model.DeviceID) (model.GroupName, error)
 	DeleteDevice(ctx context.Context, id model.DeviceID) error
@@ -181,8 +181,11 @@ func (i *inventory) UpdateDeviceGroup(
 	return nil
 }
 
-func (i *inventory) ListGroups(ctx context.Context) ([]model.GroupName, error) {
-	groups, err := i.db.ListGroups(ctx)
+func (i *inventory) ListGroups(
+	ctx context.Context,
+	filters []model.FilterPredicate,
+) ([]model.GroupName, error) {
+	groups, err := i.db.ListGroups(ctx, filters)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list groups")
 	}

--- a/inv/mocks/InventoryApp.go
+++ b/inv/mocks/InventoryApp.go
@@ -214,13 +214,13 @@ func (_m *InventoryApp) ListDevicesByGroup(ctx context.Context, group model.Grou
 	return r0, r1, r2
 }
 
-// ListGroups provides a mock function with given fields: ctx
-func (_m *InventoryApp) ListGroups(ctx context.Context) ([]model.GroupName, error) {
-	ret := _m.Called(ctx)
+// ListGroups provides a mock function with given fields: ctx, filters
+func (_m *InventoryApp) ListGroups(ctx context.Context, filters []model.FilterPredicate) ([]model.GroupName, error) {
+	ret := _m.Called(ctx, filters)
 
 	var r0 []model.GroupName
-	if rf, ok := ret.Get(0).(func(context.Context) []model.GroupName); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, []model.FilterPredicate) []model.GroupName); ok {
+		r0 = rf(ctx, filters)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]model.GroupName)
@@ -228,8 +228,8 @@ func (_m *InventoryApp) ListGroups(ctx context.Context) ([]model.GroupName, erro
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, []model.FilterPredicate) error); ok {
+		r1 = rf(ctx, filters)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -70,8 +70,9 @@ type DataStore interface {
 	// if any.
 	UpdateDevicesGroup(ctx context.Context, devIDs []model.DeviceID, group model.GroupName) (*model.UpdateResult, error)
 
-	// List groups
-	ListGroups(ctx context.Context) ([]model.GroupName, error)
+	// ListGroups returns a list of all existing groups. Devices included
+	// in the evaluation can be filtered by the filters argument.
+	ListGroups(ctx context.Context, filters []model.FilterPredicate) ([]model.GroupName, error)
 
 	// Lists devices belonging to a group
 	GetDevicesByGroup(ctx context.Context, group model.GroupName, skip, limit int) ([]model.DeviceID, int, error)

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -194,13 +194,13 @@ func (_m *DataStore) GetDevicesByGroup(ctx context.Context, group model.GroupNam
 	return r0, r1, r2
 }
 
-// ListGroups provides a mock function with given fields: ctx
-func (_m *DataStore) ListGroups(ctx context.Context) ([]model.GroupName, error) {
-	ret := _m.Called(ctx)
+// ListGroups provides a mock function with given fields: ctx, filters
+func (_m *DataStore) ListGroups(ctx context.Context, filters []model.FilterPredicate) ([]model.GroupName, error) {
+	ret := _m.Called(ctx, filters)
 
 	var r0 []model.GroupName
-	if rf, ok := ret.Get(0).(func(context.Context) []model.GroupName); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, []model.FilterPredicate) []model.GroupName); ok {
+		r0 = rf(ctx, filters)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]model.GroupName)
@@ -208,8 +208,8 @@ func (_m *DataStore) ListGroups(ctx context.Context) ([]model.GroupName, error) 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, []model.FilterPredicate) error); ok {
+		r1 = rf(ctx, filters)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
Added an optional `status` parameter to `GET /groups` to be able to filter out devices used for evaluating groups to the given status.
I made the storage and app interfaces generic in the expectation that there might come a need for `/search` like interface in the future.
Goes along with mendersoftware/gui#926.