### PR TITLE
MEN-3478: replace dot/dollar in inventory keys with unicode equivalents

### DIFF
--- a/model/device_test.go
+++ b/model/device_test.go
@@ -77,6 +77,29 @@ func TestDeviceAttributesMarshal(t *testing.T) {
 	assert.Equal(t, "[]", string(data))
 }
 
+func TestMarshalMarshalBSON(t *testing.T) {
+	dev := Device{
+		ID: "foo",
+		Attributes: DeviceAttributes{{
+			Name:  "a.b",
+			Value: "foo",
+			Scope: "bar",
+		}, {
+			Name:  "c$d",
+			Value: "foo",
+			Scope: "bar",
+		}},
+	}
+	b, err := bson.Marshal(dev)
+	if assert.NoError(t, err) {
+		var tmp Device
+
+		err := bson.Unmarshal(b, &tmp)
+		assert.NoError(t, err)
+		assert.EqualValues(t, dev, tmp)
+	}
+}
+
 func TestMarshalUnmarshalBSON(t *testing.T) {
 	str2Ptr := func(s string) *string {
 		return &s


### PR DESCRIPTION
We need to replace dots and dollars in the key used to store inventory
attributes to allow mongodb successfully store and query them without
unnecessary nesting.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>