### PR TITLE
Do not update the updated_ts timestamp in internal end-points

### DIFF
--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -401,7 +401,7 @@ func (i *inventoryHandlers) UpdateDeviceAttributesHandler(w rest.ResponseWriter,
 
 	// upsert or replace the attributes
 	if r.Method == http.MethodPatch {
-		err = i.inventory.UpsertAttributes(ctx, model.DeviceID(idata.Subject), attrs)
+		err = i.inventory.UpsertAttributesWithUpdated(ctx, model.DeviceID(idata.Subject), attrs)
 	} else if r.Method == http.MethodPut {
 		err = i.inventory.ReplaceAttributes(ctx, model.DeviceID(idata.Subject), attrs, model.AttrScopeInventory)
 	} else {

--- a/api/http/api_inventory_test.go
+++ b/api/http/api_inventory_test.go
@@ -978,7 +978,7 @@ func TestApiInventoryUpsertAttributes(t *testing.T) {
 		ctx := contextMatcher()
 
 		if tc.inReq.Method == http.MethodPatch {
-			inv.On("UpsertAttributes",
+			inv.On("UpsertAttributesWithUpdated",
 				ctx,
 				mock.AnythingOfType("model.DeviceID"),
 				mock.MatchedBy(

--- a/inv/mocks/InventoryApp.go
+++ b/inv/mocks/InventoryApp.go
@@ -392,27 +392,18 @@ func (_m *InventoryApp) UpsertAttributes(ctx context.Context, id model.DeviceID,
 	return r0
 }
 
-// UpsertDevicesAttributes provides a mock function with given fields: ctx, ids, attrs
-func (_m *InventoryApp) UpsertDevicesAttributes(ctx context.Context, ids []model.DeviceID, attrs model.DeviceAttributes) (*model.UpdateResult, error) {
-	ret := _m.Called(ctx, ids, attrs)
+// UpsertAttributesWithUpdated provides a mock function with given fields: ctx, id, attrs
+func (_m *InventoryApp) UpsertAttributesWithUpdated(ctx context.Context, id model.DeviceID, attrs model.DeviceAttributes) error {
+	ret := _m.Called(ctx, id, attrs)
 
-	var r0 *model.UpdateResult
-	if rf, ok := ret.Get(0).(func(context.Context, []model.DeviceID, model.DeviceAttributes) *model.UpdateResult); ok {
-		r0 = rf(ctx, ids, attrs)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.DeviceID, model.DeviceAttributes) error); ok {
+		r0 = rf(ctx, id, attrs)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.UpdateResult)
-		}
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, []model.DeviceID, model.DeviceAttributes) error); ok {
-		r1 = rf(ctx, ids, attrs)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // UpsertDevicesStatuses provides a mock function with given fields: ctx, devices, attrs

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -53,6 +53,14 @@ type DataStore interface {
 	// DeleteDevices removes devices with the given IDs from the database.
 	DeleteDevices(ctx context.Context, ids []model.DeviceID) (*model.UpdateResult, error)
 
+	// UpsertDevicesAttributesWithUpdated provides an interface to apply the same
+	// attribute update to multiple devices. Attribute updates are performed
+	// in a differential manner. Nonexistent attributes are created,
+	// existing are overwritten; the device resource is also created if
+	// necessary. It also sets the updated_ts timestamp to the current
+	// date and time.
+	UpsertDevicesAttributesWithUpdated(ctx context.Context, ids []model.DeviceID, attrs model.DeviceAttributes) (*model.UpdateResult, error)
+
 	// UpsertDevicesAttributes provides an interface to apply the same
 	// attribute update to multiple devices. Attribute updates are performed
 	// in a differential manner. Nonexistent attributes are created,

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -379,6 +379,29 @@ func (_m *DataStore) UpdateDevicesGroup(ctx context.Context, devIDs []model.Devi
 	return r0, r1
 }
 
+// UpsertDevicesAttributes provides a mock function with given fields: ctx, ids, attrs
+func (_m *DataStore) UpsertDevicesAttributes(ctx context.Context, ids []model.DeviceID, attrs model.DeviceAttributes) (*model.UpdateResult, error) {
+	ret := _m.Called(ctx, ids, attrs)
+
+	var r0 *model.UpdateResult
+	if rf, ok := ret.Get(0).(func(context.Context, []model.DeviceID, model.DeviceAttributes) *model.UpdateResult); ok {
+		r0 = rf(ctx, ids, attrs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.UpdateResult)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, []model.DeviceID, model.DeviceAttributes) error); ok {
+		r1 = rf(ctx, ids, attrs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpsertDevicesAttributesWithRevision provides a mock function with given fields: ctx, ids, attrs
 func (_m *DataStore) UpsertDevicesAttributesWithRevision(ctx context.Context, ids []model.DeviceUpdate, attrs model.DeviceAttributes) (*model.UpdateResult, error) {
 	ret := _m.Called(ctx, ids, attrs)
@@ -402,8 +425,8 @@ func (_m *DataStore) UpsertDevicesAttributesWithRevision(ctx context.Context, id
 	return r0, r1
 }
 
-// UpsertDevicesAttributes provides a mock function with given fields: ctx, ids, attrs
-func (_m *DataStore) UpsertDevicesAttributes(ctx context.Context, ids []model.DeviceID, attrs model.DeviceAttributes) (*model.UpdateResult, error) {
+// UpsertDevicesAttributesWithUpdated provides a mock function with given fields: ctx, ids, attrs
+func (_m *DataStore) UpsertDevicesAttributesWithUpdated(ctx context.Context, ids []model.DeviceID, attrs model.DeviceAttributes) (*model.UpdateResult, error) {
 	ret := _m.Called(ctx, ids, attrs)
 
 	var r0 *model.UpdateResult


### PR DESCRIPTION
The deviceauth service consumes the internal management API end-points
to update the inventory fields. In this case, we don't want to update
the update_ts timestamp. We provide a new method in the DataStore
(UpsertDevicesAttributesWithUpdated) which explicitly updates the
update_ts field, and we use this method from the device API end-points
consumed by the Mender Client to update the device inventory data.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>