### PR TITLE
docs: deprecate DELETE /devices/{id} management endpoint

### DIFF
--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -181,6 +181,9 @@ paths:
       security:
         - ManagementJWT: []
       summary: Remove selected device's inventory
+      description:  |
+        This endpoint is deprecated and should no longer be used.
+        Using it will leave the system in an undefined state.
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
The endpoint should never been exposed.
Using the endpoint leads to data inconsistency in the system.