### PR TITLE
MEN-4525: improve device decommissioning and inventory data reset

### DIFF
--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -83,13 +83,18 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /devices:
+  /tenants/{tenant_id}/devices:
     post:
       operationId: Initialize Device
       tags:
         - Internal API
       summary: Create a device resource with the supplied set of attributes
       parameters:
+        - name: tenant_id
+          in: path
+          description: ID of given tenant.
+          required: true
+          type: string
         - name: device
           in: body
           required: true
@@ -106,6 +111,35 @@ paths:
           description: Malformed request body. See error for details.
           schema:
             $ref: '#/definitions/Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+
+  /tenants/{tenant_id}/devices/{device_id}:
+    delete:
+      operationId: Delete Device
+      tags:
+        - Internal API
+      summary: Remove a device from the inventory service
+      parameters:
+        - name: tenant_id
+          in: path
+          description: ID of given tenant.
+          required: true
+          type: string
+        - name: device_id
+          in: path
+          description: ID of given device.
+          required: true
+          type: string
+      responses:
+        204:
+          description: Device removed
+        404:
+          description: The device was not found.
+          schema:
+            $ref: "#/definitions/Error"
         500:
           description: Internal server error.
           schema:

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -193,9 +193,6 @@ paths:
       security:
         - ManagementJWT: []
       summary: Remove selected device's inventory
-      description:  |
-        This endpoint is deprecated and should no longer be used.
-        Using it will leave the system in an undefined state.
       parameters:
         - name: id
           in: path

--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -43,7 +43,9 @@ class ManagementClient:
         http_client.session.verify = False
 
         self.client = SwaggerClient.from_spec(
-            load_file(spec), config=config, http_client=http_client,
+            load_file(spec),
+            config=config,
+            http_client=http_client,
         )
         self.client.swagger_spec.api_url = "http://%s/api/%s" % (host, api)
 
@@ -84,13 +86,19 @@ class ManagementClient:
 
     def updateTagAttributes(self, device_id, tags, eTag=None, JWT="foo.bar.baz"):
         r, _ = self.client.Management_API.Add_Tags(
-            id=device_id, If_Match=eTag, tags=tags, Authorization=JWT,
+            id=device_id,
+            If_Match=eTag,
+            tags=tags,
+            Authorization=JWT,
         ).result()
         return r
 
     def setTagAttributes(self, device_id, tags, eTag=None, JWT="foo.bar.baz"):
         r, _ = self.client.Management_API.Assign_Tags(
-            id=device_id, If_Match=eTag, tags=tags, Authorization=JWT,
+            id=device_id,
+            If_Match=eTag,
+            tags=tags,
+            Authorization=JWT,
         ).result()
         return r
 
@@ -211,7 +219,9 @@ class InternalApiClient(ApiClient):
 
     def create_tenant(self, tenant_id):
         return self.client.Internal_API.Create_Tenant(
-            tenant={"tenant_id": tenant_id,}
+            tenant={
+                "tenant_id": tenant_id,
+            }
         ).result()
 
     def create_device(self, device_id, attributes, description="test device"):
@@ -219,4 +229,6 @@ class InternalApiClient(ApiClient):
             id=device_id, description=description, attributes=attributes
         )
 
-        return self.client.Internal_API.Initialize_Device(device=device).result()
+        return self.client.Internal_API.Initialize_Device(
+            tenant_id="", device=device
+        ).result()


### PR DESCRIPTION
Introduce a new internal end-point to delete (decommission) a device
from the inventory microservice. The new end-point replaces an
equivalent one in the management APIs we deprecated because there was no
reason for users to manually trigger the decommissioning for a device.
At the same time, update the implementation of the old management
endpoint (DELETE) with a new semantic: reset the device's inventory
data, removing all the attributes in the inventory scope. This is what
the end-point was reallly about in its original intentions.

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>