### PR TITLE
fix(api-docs): type for the value attribute in the devices API docs

### DIFF
--- a/docs/devices_api.yml
+++ b/docs/devices_api.yml
@@ -139,7 +139,7 @@ definitions:
         type: string
         description: Attribute description.
       value:
-        type: string
+        type: object
         description: |
             The current value of the attribute.
 


### PR DESCRIPTION
As the mender client may provide a string or array of strings for an attribute value,  *object* is a more appropriate type for Swagger 2.0.