### PR TITLE
fix value returned by /filters/attributes endpoint

### DIFF
--- a/api/http/api_inventory.go
+++ b/api/http/api_inventory.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -893,6 +893,11 @@ func (i *inventoryHandlers) FiltersAttributesHandler(w rest.ResponseWriter, r *r
 	if err != nil {
 		u.RestErrWithLogInternal(w, r, l, err)
 		return
+	}
+
+	// in case of nil make sure we return empty list
+	if attributes == nil {
+		attributes = []model.FilterAttribute{}
 	}
 
 	_ = w.WriteJson(attributes)

--- a/api/http/api_inventory_test.go
+++ b/api/http/api_inventory_test.go
@@ -1,16 +1,16 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2023 Northern.tech AS
 //
-//    Licensed under the Apache License, Version 2.0 (the "License");
-//    you may not use this file except in compliance with the License.
-//    You may obtain a copy of the License at
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
 //
-//        http://www.apache.org/licenses/LICENSE-2.0
+//	    http://www.apache.org/licenses/LICENSE-2.0
 //
-//    Unless required by applicable law or agreed to in writing, software
-//    distributed under the License is distributed on an "AS IS" BASIS,
-//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//    See the License for the specific language governing permissions and
-//    limitations under the License.
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
 package http
 
 import (

--- a/api/http/api_inventory_test.go
+++ b/api/http/api_inventory_test.go
@@ -2950,6 +2950,10 @@ func TestApiInventoryFiltersAttributes(t *testing.T) {
 			},
 			httpCode: http.StatusOK,
 		},
+		"ok, no attributes": {
+			attributes: nil,
+			httpCode:   http.StatusOK,
+		},
 		"ko": {
 			err:      errors.New("error"),
 			httpCode: http.StatusInternalServerError,
@@ -2969,6 +2973,9 @@ func TestApiInventoryFiltersAttributes(t *testing.T) {
 
 			recorded.CodeIs(tc.httpCode)
 			if tc.httpCode == http.StatusOK {
+				if tc.attributes == nil {
+					tc.attributes = []model.FilterAttribute{}
+				}
 				body, _ := json.Marshal(tc.attributes)
 				recorded.BodyIs(string(body))
 			}


### PR DESCRIPTION
Ticket: MEN-6477

In the /filters/attributes endpoint, in case there are no attributes,
return empty list instead of null.